### PR TITLE
Add signature test helpers and Stripe provider tests

### DIFF
--- a/src/providers/stripe.ts
+++ b/src/providers/stripe.ts
@@ -18,23 +18,27 @@ export function stripe(options: StripeOptions): WebhookProvider {
 				return { valid: false, reason: "missing-signature" };
 			}
 
-			const pairs = header.split(",").reduce(
-				(acc, pair) => {
-					const [key, value] = pair.split("=");
-					acc[key.trim()] = value;
-					return acc;
-				},
-				{} as Record<string, string>,
-			);
+			const pairs: Record<string, string[]> = {};
+			for (const part of header.split(",")) {
+				const idx = part.indexOf("=");
+				if (idx === -1) continue;
+				const key = part.slice(0, idx).trim();
+				const value = part.slice(idx + 1).trim();
+				if (!pairs[key]) pairs[key] = [];
+				pairs[key].push(value);
+			}
 
-			const timestamp = pairs.t;
-			const signature = pairs.v1;
+			const timestamp = pairs.t?.[0];
+			const signatures = pairs.v1 ?? [];
 
-			if (!timestamp || !signature) {
+			if (!timestamp || signatures.length === 0) {
 				return { valid: false, reason: "missing-signature" };
 			}
 
 			const ts = Number(timestamp);
+			if (!Number.isFinite(ts) || ts <= 0) {
+				return { valid: false, reason: "missing-signature" };
+			}
 			const now = Math.floor(Date.now() / 1000);
 			if (Math.abs(now - ts) > tolerance) {
 				return { valid: false, reason: "timestamp-expired" };
@@ -43,7 +47,7 @@ export function stripe(options: StripeOptions): WebhookProvider {
 			const payload = `${timestamp}.${rawBody}`;
 			const expected = toHex(await hmac("SHA-256", secret, payload));
 
-			if (!timingSafeEqual(expected, signature)) {
+			if (!signatures.some((sig) => timingSafeEqual(expected, sig))) {
 				return { valid: false, reason: "invalid-signature" };
 			}
 

--- a/tests/helpers/signatures.ts
+++ b/tests/helpers/signatures.ts
@@ -1,0 +1,45 @@
+import { hmac, toBase64, toHex } from "../../src/crypto.js";
+
+export async function generateStripeSignature(
+	body: string,
+	secret: string,
+	timestamp?: number,
+): Promise<{ header: string; timestamp: number }> {
+	const ts = timestamp ?? Math.floor(Date.now() / 1000);
+	const payload = `${ts}.${body}`;
+	const sig = toHex(await hmac("SHA-256", secret, payload));
+	return { header: `t=${ts},v1=${sig}`, timestamp: ts };
+}
+
+export async function generateGitHubSignature(body: string, secret: string): Promise<string> {
+	const sig = toHex(await hmac("SHA-256", secret, body));
+	return `sha256=${sig}`;
+}
+
+export async function generateSlackSignature(
+	body: string,
+	secret: string,
+	timestamp?: number,
+): Promise<{ signature: string; timestamp: number }> {
+	const ts = timestamp ?? Math.floor(Date.now() / 1000);
+	const sigBasestring = `v0:${ts}:${body}`;
+	const sig = toHex(await hmac("SHA-256", secret, sigBasestring));
+	return { signature: `v0=${sig}`, timestamp: ts };
+}
+
+export async function generateShopifySignature(body: string, secret: string): Promise<string> {
+	return toBase64(await hmac("SHA-256", secret, body));
+}
+
+export async function generateTwilioSignature(
+	url: string,
+	params: Record<string, string>,
+	authToken: string,
+): Promise<string> {
+	const sortedKeys = Object.keys(params).sort();
+	let dataToSign = url;
+	for (const key of sortedKeys) {
+		dataToSign += key + params[key];
+	}
+	return toBase64(await hmac("SHA-1", authToken, dataToSign));
+}

--- a/tests/providers/stripe.test.ts
+++ b/tests/providers/stripe.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from "vitest";
+import { stripe } from "../../src/providers/stripe.js";
+import { generateStripeSignature } from "../helpers/signatures.js";
+
+const SECRET = "whsec_test_secret";
+const BODY = '{"type":"checkout.session.completed"}';
+
+describe("stripe provider", () => {
+	it("verifies valid signature", async () => {
+		const provider = stripe({ secret: SECRET });
+		const { header } = await generateStripeSignature(BODY, SECRET);
+		const result = await provider.verify({
+			rawBody: BODY,
+			headers: new Headers({ "Stripe-Signature": header }),
+			secret: SECRET,
+		});
+		expect(result).toEqual({ valid: true });
+	});
+
+	it("rejects tampered body", async () => {
+		const provider = stripe({ secret: SECRET });
+		const { header } = await generateStripeSignature(BODY, SECRET);
+		const result = await provider.verify({
+			rawBody: `${BODY}tampered`,
+			headers: new Headers({ "Stripe-Signature": header }),
+			secret: SECRET,
+		});
+		expect(result.valid).toBe(false);
+		expect(result.reason).toBe("invalid-signature");
+	});
+
+	it("rejects wrong secret", async () => {
+		const provider = stripe({ secret: SECRET });
+		const { header } = await generateStripeSignature(BODY, "wrong_secret");
+		const result = await provider.verify({
+			rawBody: BODY,
+			headers: new Headers({ "Stripe-Signature": header }),
+			secret: SECRET,
+		});
+		expect(result.valid).toBe(false);
+		expect(result.reason).toBe("invalid-signature");
+	});
+
+	it("rejects missing signature header", async () => {
+		const provider = stripe({ secret: SECRET });
+		const result = await provider.verify({
+			rawBody: BODY,
+			headers: new Headers(),
+			secret: SECRET,
+		});
+		expect(result).toEqual({ valid: false, reason: "missing-signature" });
+	});
+
+	it("verifies empty body", async () => {
+		const provider = stripe({ secret: SECRET });
+		const { header } = await generateStripeSignature("", SECRET);
+		const result = await provider.verify({
+			rawBody: "",
+			headers: new Headers({ "Stripe-Signature": header }),
+			secret: SECRET,
+		});
+		expect(result).toEqual({ valid: true });
+	});
+
+	it("verifies multibyte body", async () => {
+		const provider = stripe({ secret: SECRET });
+		const body = '{"message":"こんにちは世界"}';
+		const { header } = await generateStripeSignature(body, SECRET);
+		const result = await provider.verify({
+			rawBody: body,
+			headers: new Headers({ "Stripe-Signature": header }),
+			secret: SECRET,
+		});
+		expect(result).toEqual({ valid: true });
+	});
+
+	it("rejects expired timestamp", async () => {
+		const provider = stripe({ secret: SECRET });
+		const sixMinAgo = Math.floor(Date.now() / 1000) - 360;
+		const { header } = await generateStripeSignature(BODY, SECRET, sixMinAgo);
+		const result = await provider.verify({
+			rawBody: BODY,
+			headers: new Headers({ "Stripe-Signature": header }),
+			secret: SECRET,
+		});
+		expect(result).toEqual({ valid: false, reason: "timestamp-expired" });
+	});
+
+	it("respects custom tolerance", async () => {
+		const provider = stripe({ secret: SECRET, tolerance: 60 });
+		const twoMinAgo = Math.floor(Date.now() / 1000) - 120;
+		const { header } = await generateStripeSignature(BODY, SECRET, twoMinAgo);
+		const result = await provider.verify({
+			rawBody: BODY,
+			headers: new Headers({ "Stripe-Signature": header }),
+			secret: SECRET,
+		});
+		expect(result).toEqual({ valid: false, reason: "timestamp-expired" });
+	});
+
+	it("rejects non-numeric timestamp", async () => {
+		const provider = stripe({ secret: SECRET });
+		const result = await provider.verify({
+			rawBody: BODY,
+			headers: new Headers({
+				"Stripe-Signature": "t=abc,v1=fakesig",
+			}),
+			secret: SECRET,
+		});
+		expect(result).toEqual({ valid: false, reason: "missing-signature" });
+	});
+
+	it("rejects malformed header without t= or v1=", async () => {
+		const provider = stripe({ secret: SECRET });
+		const result = await provider.verify({
+			rawBody: BODY,
+			headers: new Headers({ "Stripe-Signature": "invalid_header_format" }),
+			secret: SECRET,
+		});
+		expect(result).toEqual({ valid: false, reason: "missing-signature" });
+	});
+});


### PR DESCRIPTION
Closes #3

## Summary
- Add `tests/helpers/signatures.ts` with signature generation helpers for all 5 providers (Stripe, GitHub, Slack, Shopify, Twilio)
- Add `tests/providers/stripe.test.ts` with 10 tests covering P1-P6 (common) + T1-T3 (timestamp) + edge cases
- Fix Stripe header parser to use `indexOf("=")` for correct value extraction and support multiple `v1` signatures
- Guard against NaN timestamp bypass — reject non-numeric `t=` values
- Trim whitespace from parsed header values

## Test plan
- [x] P1: Valid signature → success
- [x] P2: Tampered body → invalid-signature
- [x] P3: Wrong secret → invalid-signature
- [x] P4: Missing header → missing-signature
- [x] P5: Empty body → success
- [x] P6: Multibyte body → success
- [x] T2: Expired timestamp → timestamp-expired
- [x] T3: Custom tolerance → respected
- [x] Non-numeric timestamp → missing-signature
- [x] Malformed header → missing-signature

🤖 Generated with [Claude Code](https://claude.com/claude-code)