### PR TITLE
Add middleware integration tests (M1-M8)

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,5 +1,6 @@
 import { createMiddleware } from "hono/factory";
-import { bodyReadFailed } from "./errors.js";
+import type { ContentfulStatusCode } from "hono/utils/http-status";
+import { bodyReadFailed, invalidSignature, missingSignature, timestampExpired } from "./errors.js";
 import type { WebhookVerifyOptions, WebhookVerifyVariables } from "./types.js";
 
 export function webhookVerify(options: WebhookVerifyOptions) {
@@ -18,22 +19,19 @@ export function webhookVerify(options: WebhookVerifyOptions) {
 		const result = await provider.verify({
 			rawBody,
 			headers: c.req.raw.headers,
-			secret: "",
 			url: c.req.url,
 		});
 
 		if (!result.valid) {
-			const errorFactory = await import("./errors.js");
 			const reason = result.reason ?? "invalid-signature";
-			const errorFn =
-				reason === "missing-signature"
-					? errorFactory.missingSignature
-					: reason === "timestamp-expired"
-						? errorFactory.timestampExpired
-						: errorFactory.invalidSignature;
+			const errorFns: Record<string, typeof invalidSignature> = {
+				"missing-signature": missingSignature,
+				"timestamp-expired": timestampExpired,
+			};
+			const errorFn = errorFns[reason] ?? invalidSignature;
 			const error = errorFn(result.reason ?? "Signature verification failed");
 			if (onError) return onError(error, c);
-			return c.json(error, error.status as 400 | 401);
+			return c.json(error, error.status as ContentfulStatusCode);
 		}
 
 		c.set("webhookRawBody", rawBody);

--- a/src/providers/types.ts
+++ b/src/providers/types.ts
@@ -8,7 +8,6 @@ export interface VerifyResult {
 export interface VerifyContext {
 	rawBody: string;
 	headers: Headers;
-	secret: string;
 	/** Required for Twilio (URL is part of the signature payload) */
 	url?: string;
 }

--- a/tests/middleware.test.ts
+++ b/tests/middleware.test.ts
@@ -1,0 +1,130 @@
+import type { Context } from "hono";
+import { Hono } from "hono";
+import { describe, expect, it } from "vitest";
+import { webhookVerify } from "../src/middleware.js";
+import { github } from "../src/providers/github.js";
+import { stripe } from "../src/providers/stripe.js";
+import type { WebhookVerifyVariables } from "../src/types.js";
+import { generateGitHubSignature, generateStripeSignature } from "./helpers/signatures.js";
+
+const GITHUB_SECRET = "gh_test_secret";
+const STRIPE_SECRET = "whsec_test_secret";
+const BODY = '{"event":"test"}';
+
+function createGitHubApp(handler?: (c: Context) => Response | Promise<Response>) {
+	const app = new Hono<{ Variables: WebhookVerifyVariables }>();
+	app.post(
+		"/webhook",
+		webhookVerify({ provider: github({ secret: GITHUB_SECRET }) }),
+		handler ?? ((c) => c.json({ ok: true })),
+	);
+	return app;
+}
+
+async function githubRequest(
+	app: Hono<{ Variables: WebhookVerifyVariables }>,
+	headers?: Record<string, string>,
+): Promise<Response> {
+	const signature = await generateGitHubSignature(BODY, GITHUB_SECRET);
+	return app.request("/webhook", {
+		method: "POST",
+		body: BODY,
+		headers: { "X-Hub-Signature-256": signature, ...headers },
+	});
+}
+
+function createStripeApp() {
+	const app = new Hono<{ Variables: WebhookVerifyVariables }>();
+	app.post("/webhook", webhookVerify({ provider: stripe({ secret: STRIPE_SECRET }) }), (c) =>
+		c.json({ ok: true }),
+	);
+	return app;
+}
+
+describe("webhookVerify middleware", () => {
+	it("M1: passes valid signature and returns handler response", async () => {
+		const app = createGitHubApp();
+		const res = await githubRequest(app);
+		expect(res.status).toBe(200);
+		expect(await res.json()).toEqual({ ok: true });
+	});
+
+	it("M2: rejects invalid signature with 401", async () => {
+		const app = createGitHubApp();
+		const signature = await generateGitHubSignature(BODY, "wrong_secret");
+		const res = await app.request("/webhook", {
+			method: "POST",
+			body: BODY,
+			headers: { "X-Hub-Signature-256": signature },
+		});
+		expect(res.status).toBe(401);
+		const body = await res.json();
+		expect(body.title).toBeDefined();
+		expect(body.type).toContain("invalid-signature");
+	});
+
+	it("M3: rejects missing signature header with 401", async () => {
+		const app = createGitHubApp();
+		const res = await app.request("/webhook", {
+			method: "POST",
+			body: BODY,
+		});
+		expect(res.status).toBe(401);
+		const body = await res.json();
+		expect(body.type).toContain("missing-signature");
+	});
+
+	it("M4: rejects expired timestamp with 401 (Stripe)", async () => {
+		const app = createStripeApp();
+		const sixMinAgo = Math.floor(Date.now() / 1000) - 360;
+		const { header } = await generateStripeSignature(BODY, STRIPE_SECRET, sixMinAgo);
+		const res = await app.request("/webhook", {
+			method: "POST",
+			body: BODY,
+			headers: { "Stripe-Signature": header },
+		});
+		expect(res.status).toBe(401);
+		const body = await res.json();
+		expect(body.type).toContain("timestamp-expired");
+	});
+
+	it("M5: sets webhookRawBody on context", async () => {
+		const app = createGitHubApp((c) => c.text(c.get("webhookRawBody")));
+		const res = await githubRequest(app);
+		expect(res.status).toBe(200);
+		expect(await res.text()).toBe(BODY);
+	});
+
+	it("M6: sets webhookPayload on context as parsed JSON", async () => {
+		const app = createGitHubApp((c) => c.json(c.get("webhookPayload")));
+		const res = await githubRequest(app);
+		expect(res.status).toBe(200);
+		expect(await res.json()).toEqual({ event: "test" });
+	});
+
+	it("M7: sets webhookProvider on context", async () => {
+		const app = createGitHubApp((c) => c.text(c.get("webhookProvider")));
+		const res = await githubRequest(app);
+		expect(res.status).toBe(200);
+		expect(await res.text()).toBe("github");
+	});
+
+	it("M8: custom onError returns custom response", async () => {
+		const app = new Hono<{ Variables: WebhookVerifyVariables }>();
+		app.post(
+			"/webhook",
+			webhookVerify({
+				provider: github({ secret: GITHUB_SECRET }),
+				onError: (error, c) => c.json({ custom: true, reason: error.detail }, 403),
+			}),
+			(c) => c.json({ ok: true }),
+		);
+		const res = await app.request("/webhook", {
+			method: "POST",
+			body: BODY,
+		});
+		expect(res.status).toBe(403);
+		const body = await res.json();
+		expect(body.custom).toBe(true);
+	});
+});

--- a/tests/providers/github.test.ts
+++ b/tests/providers/github.test.ts
@@ -12,7 +12,6 @@ describe("github provider", () => {
 		const result = await provider.verify({
 			rawBody: BODY,
 			headers: new Headers({ "X-Hub-Signature-256": signature }),
-			secret: SECRET,
 		});
 		expect(result).toEqual({ valid: true });
 	});
@@ -23,7 +22,6 @@ describe("github provider", () => {
 		const result = await provider.verify({
 			rawBody: `${BODY}tampered`,
 			headers: new Headers({ "X-Hub-Signature-256": signature }),
-			secret: SECRET,
 		});
 		expect(result).toEqual({ valid: false, reason: "invalid-signature" });
 	});
@@ -34,7 +32,6 @@ describe("github provider", () => {
 		const result = await provider.verify({
 			rawBody: BODY,
 			headers: new Headers({ "X-Hub-Signature-256": signature }),
-			secret: SECRET,
 		});
 		expect(result).toEqual({ valid: false, reason: "invalid-signature" });
 	});
@@ -44,7 +41,6 @@ describe("github provider", () => {
 		const result = await provider.verify({
 			rawBody: BODY,
 			headers: new Headers(),
-			secret: SECRET,
 		});
 		expect(result).toEqual({ valid: false, reason: "missing-signature" });
 	});
@@ -55,7 +51,6 @@ describe("github provider", () => {
 		const result = await provider.verify({
 			rawBody: "",
 			headers: new Headers({ "X-Hub-Signature-256": signature }),
-			secret: SECRET,
 		});
 		expect(result).toEqual({ valid: true });
 	});
@@ -67,7 +62,6 @@ describe("github provider", () => {
 		const result = await provider.verify({
 			rawBody: body,
 			headers: new Headers({ "X-Hub-Signature-256": signature }),
-			secret: SECRET,
 		});
 		expect(result).toEqual({ valid: true });
 	});
@@ -82,7 +76,6 @@ describe("github provider", () => {
 			headers: new Headers({
 				"X-Hub-Signature-256": "not_a_valid_format",
 			}),
-			secret: SECRET,
 		});
 		expect(result).toEqual({ valid: false, reason: "invalid-signature" });
 	});
@@ -92,7 +85,6 @@ describe("github provider", () => {
 		const result = await provider.verify({
 			rawBody: BODY,
 			headers: new Headers({ "X-Hub-Signature-256": "sha256=deadbeef" }),
-			secret: SECRET,
 		});
 		expect(result).toEqual({ valid: false, reason: "invalid-signature" });
 	});
@@ -103,7 +95,6 @@ describe("github provider", () => {
 		const result = await provider.verify({
 			rawBody: BODY,
 			headers: new Headers({ "X-Hub-Signature-256": `sha256=${hex}` }),
-			secret: SECRET,
 		});
 		expect(result).toEqual({ valid: false, reason: "invalid-signature" });
 	});

--- a/tests/providers/stripe.test.ts
+++ b/tests/providers/stripe.test.ts
@@ -12,7 +12,6 @@ describe("stripe provider", () => {
 		const result = await provider.verify({
 			rawBody: BODY,
 			headers: new Headers({ "Stripe-Signature": header }),
-			secret: SECRET,
 		});
 		expect(result).toEqual({ valid: true });
 	});
@@ -23,7 +22,6 @@ describe("stripe provider", () => {
 		const result = await provider.verify({
 			rawBody: `${BODY}tampered`,
 			headers: new Headers({ "Stripe-Signature": header }),
-			secret: SECRET,
 		});
 		expect(result.valid).toBe(false);
 		expect(result.reason).toBe("invalid-signature");
@@ -35,7 +33,6 @@ describe("stripe provider", () => {
 		const result = await provider.verify({
 			rawBody: BODY,
 			headers: new Headers({ "Stripe-Signature": header }),
-			secret: SECRET,
 		});
 		expect(result.valid).toBe(false);
 		expect(result.reason).toBe("invalid-signature");
@@ -46,7 +43,6 @@ describe("stripe provider", () => {
 		const result = await provider.verify({
 			rawBody: BODY,
 			headers: new Headers(),
-			secret: SECRET,
 		});
 		expect(result).toEqual({ valid: false, reason: "missing-signature" });
 	});
@@ -57,7 +53,6 @@ describe("stripe provider", () => {
 		const result = await provider.verify({
 			rawBody: "",
 			headers: new Headers({ "Stripe-Signature": header }),
-			secret: SECRET,
 		});
 		expect(result).toEqual({ valid: true });
 	});
@@ -69,7 +64,6 @@ describe("stripe provider", () => {
 		const result = await provider.verify({
 			rawBody: body,
 			headers: new Headers({ "Stripe-Signature": header }),
-			secret: SECRET,
 		});
 		expect(result).toEqual({ valid: true });
 	});
@@ -81,7 +75,6 @@ describe("stripe provider", () => {
 		const result = await provider.verify({
 			rawBody: BODY,
 			headers: new Headers({ "Stripe-Signature": header }),
-			secret: SECRET,
 		});
 		expect(result).toEqual({ valid: false, reason: "timestamp-expired" });
 	});
@@ -93,7 +86,6 @@ describe("stripe provider", () => {
 		const result = await provider.verify({
 			rawBody: BODY,
 			headers: new Headers({ "Stripe-Signature": header }),
-			secret: SECRET,
 		});
 		expect(result).toEqual({ valid: false, reason: "timestamp-expired" });
 	});
@@ -105,7 +97,6 @@ describe("stripe provider", () => {
 			headers: new Headers({
 				"Stripe-Signature": "t=abc,v1=fakesig",
 			}),
-			secret: SECRET,
 		});
 		expect(result).toEqual({ valid: false, reason: "missing-signature" });
 	});
@@ -115,7 +106,6 @@ describe("stripe provider", () => {
 		const result = await provider.verify({
 			rawBody: BODY,
 			headers: new Headers({ "Stripe-Signature": "invalid_header_format" }),
-			secret: SECRET,
 		});
 		expect(result).toEqual({ valid: false, reason: "missing-signature" });
 	});


### PR DESCRIPTION
Closes #7

## Summary
- Add `tests/middleware.test.ts` with 8 integration tests using `app.request()`
- Replace dynamic `import("./errors.js")` with static imports
- Replace nested ternary with lookup map for error routing
- Remove vestigial `secret` field from `VerifyContext` (all providers use closure-captured secrets)
- Use `ContentfulStatusCode` from Hono for proper type safety on `c.json()` status

## Test plan
- [x] M1: Valid signature → 200 + handler response
- [x] M2: Invalid signature → 401 RFC 9457 error
- [x] M3: Missing signature header → 401 missing-signature
- [x] M4: Timestamp expired → 401 timestamp-expired (Stripe)
- [x] M5: `c.get('webhookRawBody')` returns original body
- [x] M6: `c.get('webhookPayload')` returns parsed JSON
- [x] M7: `c.get('webhookProvider')` returns "github"
- [x] M8: Custom `onError` returns custom 403 response
- [x] All 51 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)