### PR TITLE
Add Shopify provider tests (P1-P6)

### DIFF
--- a/tests/providers/shopify.test.ts
+++ b/tests/providers/shopify.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+import { shopify } from "../../src/providers/shopify.js";
+import { generateShopifySignature } from "../helpers/signatures.js";
+
+const SECRET = "shopify_webhook_secret";
+const BODY = '{"id":1,"topic":"orders/create"}';
+
+describe("shopify provider", () => {
+	it("verifies valid signature", async () => {
+		const provider = shopify({ secret: SECRET });
+		const signature = await generateShopifySignature(BODY, SECRET);
+		const result = await provider.verify({
+			rawBody: BODY,
+			headers: new Headers({ "X-Shopify-Hmac-Sha256": signature }),
+		});
+		expect(result).toEqual({ valid: true });
+	});
+
+	it("rejects tampered body", async () => {
+		const provider = shopify({ secret: SECRET });
+		const signature = await generateShopifySignature(BODY, SECRET);
+		const result = await provider.verify({
+			rawBody: `${BODY}tampered`,
+			headers: new Headers({ "X-Shopify-Hmac-Sha256": signature }),
+		});
+		expect(result).toEqual({ valid: false, reason: "invalid-signature" });
+	});
+
+	it("rejects wrong secret", async () => {
+		const provider = shopify({ secret: SECRET });
+		const signature = await generateShopifySignature(BODY, "wrong_secret");
+		const result = await provider.verify({
+			rawBody: BODY,
+			headers: new Headers({ "X-Shopify-Hmac-Sha256": signature }),
+		});
+		expect(result).toEqual({ valid: false, reason: "invalid-signature" });
+	});
+
+	it("rejects missing signature header", async () => {
+		const provider = shopify({ secret: SECRET });
+		const result = await provider.verify({
+			rawBody: BODY,
+			headers: new Headers(),
+		});
+		expect(result).toEqual({ valid: false, reason: "missing-signature" });
+	});
+
+	it("verifies empty body", async () => {
+		const provider = shopify({ secret: SECRET });
+		const signature = await generateShopifySignature("", SECRET);
+		const result = await provider.verify({
+			rawBody: "",
+			headers: new Headers({ "X-Shopify-Hmac-Sha256": signature }),
+		});
+		expect(result).toEqual({ valid: true });
+	});
+
+	it("verifies multibyte body", async () => {
+		const provider = shopify({ secret: SECRET });
+		const body = '{"name":"こんにちは"}';
+		const signature = await generateShopifySignature(body, SECRET);
+		const result = await provider.verify({
+			rawBody: body,
+			headers: new Headers({ "X-Shopify-Hmac-Sha256": signature }),
+		});
+		expect(result).toEqual({ valid: true });
+	});
+
+	it("rejects invalid base64 signature", async () => {
+		const provider = shopify({ secret: SECRET });
+		const result = await provider.verify({
+			rawBody: BODY,
+			headers: new Headers({ "X-Shopify-Hmac-Sha256": "!!!invalid-base64!!!" }),
+		});
+		expect(result).toEqual({ valid: false, reason: "invalid-signature" });
+	});
+});


### PR DESCRIPTION
Closes #11

## Summary
- Add `tests/providers/shopify.test.ts` with 7 tests (P1-P6 common + invalid base64)

## Test plan
- [x] P1-P6: Valid, tampered, wrong secret, missing header, empty body, multibyte
- [x] Invalid base64 signature → invalid-signature
- [x] All 68 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)