### PR TITLE
Add release workflow for npm publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,38 @@
+name: Release
+
+on:
+  push:
+    branches: [main]
+
+concurrency: ${{ github.workflow }}-${{ github.ref }}
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+          registry-url: "https://registry.npmjs.org"
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Create Release Pull Request or Publish
+        id: changesets
+        uses: changesets/action@v1
+        with:
+          publish: pnpm release
+          version: pnpm version-packages
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -150,9 +150,9 @@ TDD で進める。テスト → 実装 → リファクタの順。
 ## Phase 3: Publish & Promote (Week 3)
 
 ### 3.1 パッケージング
-- [ ] README.md (English) — "Verify webhooks from any provider with one line"
-- [ ] LICENSE (MIT)
-- [ ] サブパスエクスポート設定
+- [x] README.md (English) — "Verify webhooks from any provider with one line"
+- [x] LICENSE (MIT)
+- [x] サブパスエクスポート設定
 - [ ] npm publish + JSR publish
 
 ### 3.2 Hono 公式への PR


### PR DESCRIPTION
Closes #23

## Summary
- Add `.github/workflows/release.yml` using `changesets/action@v1`
- Automatically creates "Version Packages" PR when changesets exist
- Publishes to npm with provenance when the version PR is merged
- Requires `NPM_TOKEN` secret to be configured in repo settings

## Test plan
- [x] All 81 tests pass
- [x] Lint and typecheck pass
- [x] Workflow YAML is valid (no untrusted input in `run:` steps)

🤖 Generated with [Claude Code](https://claude.com/claude-code)