### PR TITLE
Add LINE Messaging API webhook provider

### DIFF
--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -172,4 +172,4 @@ TDD で進める。テスト → 実装 → リファクタの順。
 - [ ] PayPal Provider
 - [ ] Standard Webhooks (svix 互換) Provider
 - [ ] プロバイダー自動検出（ヘッダーからプロバイダーを推定）
-- [ ] CONTRIBUTING.md — プロバイダー追加ガイド（コントリビューション誘引）
+- [x] CONTRIBUTING.md — プロバイダー追加ガイド（コントリビューション誘引）

--- a/package.json
+++ b/package.json
@@ -66,6 +66,16 @@
 				"types": "./dist/providers/twilio.d.cts",
 				"default": "./dist/providers/twilio.cjs"
 			}
+		},
+		"./providers/line": {
+			"import": {
+				"types": "./dist/providers/line.d.ts",
+				"default": "./dist/providers/line.js"
+			},
+			"require": {
+				"types": "./dist/providers/line.d.cts",
+				"default": "./dist/providers/line.cjs"
+			}
 		}
 	},
 	"sideEffects": false,

--- a/src/providers/line.ts
+++ b/src/providers/line.ts
@@ -1,0 +1,28 @@
+import { fromBase64, hmac, timingSafeEqual } from "../crypto.js";
+import type { WebhookProvider } from "./types.js";
+
+interface LineOptions {
+	channelSecret: string;
+}
+
+export function line(options: LineOptions): WebhookProvider {
+	const { channelSecret } = options;
+
+	return {
+		name: "line",
+		async verify({ rawBody, headers }) {
+			const header = headers.get("X-Line-Signature");
+			if (!header) {
+				return { valid: false, reason: "missing-signature" };
+			}
+
+			const expected = await hmac("SHA-256", channelSecret, rawBody);
+			const received = fromBase64(header);
+			if (received === null || !timingSafeEqual(expected, received)) {
+				return { valid: false, reason: "invalid-signature" };
+			}
+
+			return { valid: true };
+		},
+	};
+}

--- a/tests/helpers/signatures.ts
+++ b/tests/helpers/signatures.ts
@@ -31,6 +31,10 @@ export async function generateShopifySignature(body: string, secret: string): Pr
 	return toBase64(await hmac("SHA-256", secret, body));
 }
 
+export async function generateLineSignature(body: string, channelSecret: string): Promise<string> {
+	return toBase64(await hmac("SHA-256", channelSecret, body));
+}
+
 export async function generateTwilioSignature(
 	url: string,
 	params: Record<string, string>,

--- a/tests/providers/line.test.ts
+++ b/tests/providers/line.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+import { line } from "../../src/providers/line.js";
+import { generateLineSignature } from "../helpers/signatures.js";
+
+const SECRET = "line_channel_secret";
+const BODY = '{"events":[{"type":"message"}]}';
+
+describe("line provider", () => {
+	it("P1: verifies valid signature", async () => {
+		const provider = line({ channelSecret: SECRET });
+		const signature = await generateLineSignature(BODY, SECRET);
+		const result = await provider.verify({
+			rawBody: BODY,
+			headers: new Headers({ "X-Line-Signature": signature }),
+		});
+		expect(result).toEqual({ valid: true });
+	});
+
+	it("P2: rejects tampered body", async () => {
+		const provider = line({ channelSecret: SECRET });
+		const signature = await generateLineSignature(BODY, SECRET);
+		const result = await provider.verify({
+			rawBody: '{"events":[{"type":"tampered"}]}',
+			headers: new Headers({ "X-Line-Signature": signature }),
+		});
+		expect(result).toEqual({ valid: false, reason: "invalid-signature" });
+	});
+
+	it("P3: rejects wrong secret", async () => {
+		const provider = line({ channelSecret: SECRET });
+		const signature = await generateLineSignature(BODY, "wrong_secret");
+		const result = await provider.verify({
+			rawBody: BODY,
+			headers: new Headers({ "X-Line-Signature": signature }),
+		});
+		expect(result).toEqual({ valid: false, reason: "invalid-signature" });
+	});
+
+	it("P4: rejects missing signature header", async () => {
+		const provider = line({ channelSecret: SECRET });
+		const result = await provider.verify({
+			rawBody: BODY,
+			headers: new Headers(),
+		});
+		expect(result).toEqual({ valid: false, reason: "missing-signature" });
+	});
+
+	it("P5: verifies empty body", async () => {
+		const provider = line({ channelSecret: SECRET });
+		const signature = await generateLineSignature("", SECRET);
+		const result = await provider.verify({
+			rawBody: "",
+			headers: new Headers({ "X-Line-Signature": signature }),
+		});
+		expect(result).toEqual({ valid: true });
+	});
+
+	it("P6: verifies multibyte body", async () => {
+		const provider = line({ channelSecret: SECRET });
+		const body = '{"text":"こんにちは世界"}';
+		const signature = await generateLineSignature(body, SECRET);
+		const result = await provider.verify({
+			rawBody: body,
+			headers: new Headers({ "X-Line-Signature": signature }),
+		});
+		expect(result).toEqual({ valid: true });
+	});
+
+	it("rejects invalid base64 signature", async () => {
+		const provider = line({ channelSecret: SECRET });
+		const result = await provider.verify({
+			rawBody: BODY,
+			headers: new Headers({ "X-Line-Signature": "not-valid-base64!!!" }),
+		});
+		expect(result).toEqual({ valid: false, reason: "invalid-signature" });
+	});
+});

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -8,6 +8,7 @@ export default defineConfig({
 		"providers/slack": "src/providers/slack.ts",
 		"providers/shopify": "src/providers/shopify.ts",
 		"providers/twilio": "src/providers/twilio.ts",
+		"providers/line": "src/providers/line.ts",
 	},
 	format: ["esm", "cjs"],
 	dts: true,


### PR DESCRIPTION
Closes #27

## Summary
- Add `src/providers/line.ts` — LINE webhook signature verification (HMAC-SHA256 + base64)
- Add `tests/providers/line.test.ts` — P1-P6 + invalid base64 test (7 tests)
- Add `generateLineSignature()` test helper
- Add subpath export: `hono-webhook-verify/providers/line`

## Test plan
- [x] 88 tests pass (81 existing + 7 new LINE tests)
- [x] Lint, typecheck, and build pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)