### PR TITLE
Add Discord interaction webhook provider (Ed25519)

### DIFF
--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -167,7 +167,7 @@ TDD で進める。テスト → 実装 → リファクタの順。
 
 ## Stretch Goals
 
-- [ ] LINE Provider
+- [x] LINE Provider
 - [ ] Discord Provider
 - [ ] PayPal Provider
 - [ ] Standard Webhooks (svix 互換) Provider

--- a/package.json
+++ b/package.json
@@ -76,6 +76,16 @@
 				"types": "./dist/providers/line.d.cts",
 				"default": "./dist/providers/line.cjs"
 			}
+		},
+		"./providers/discord": {
+			"import": {
+				"types": "./dist/providers/discord.d.ts",
+				"default": "./dist/providers/discord.js"
+			},
+			"require": {
+				"types": "./dist/providers/discord.d.cts",
+				"default": "./dist/providers/discord.cjs"
+			}
 		}
 	},
 	"sideEffects": false,

--- a/src/providers/discord.ts
+++ b/src/providers/discord.ts
@@ -1,0 +1,57 @@
+import { fromHex } from "../crypto.js";
+import type { WebhookProvider } from "./types.js";
+
+interface DiscordOptions {
+	publicKey: string;
+}
+
+const encoder = new TextEncoder();
+
+export function discord(options: DiscordOptions): WebhookProvider {
+	const { publicKey } = options;
+
+	const rawKey = fromHex(publicKey);
+	if (!rawKey) {
+		throw new Error("discord: publicKey must be a valid hex string");
+	}
+	// Store in a typed variable so TypeScript narrows across the closure.
+	const keyBytes: ArrayBuffer = rawKey;
+
+	let cachedKey: CryptoKey | null = null;
+
+	async function getKey(): Promise<CryptoKey> {
+		if (cachedKey) return cachedKey;
+		cachedKey = await crypto.subtle.importKey("raw", keyBytes, "Ed25519", false, ["verify"]);
+		return cachedKey;
+	}
+
+	return {
+		name: "discord",
+		async verify({ rawBody, headers }) {
+			const signature = headers.get("X-Signature-Ed25519");
+			const timestamp = headers.get("X-Signature-Timestamp");
+
+			if (!signature || !timestamp) {
+				return { valid: false, reason: "missing-signature" };
+			}
+
+			const sigBytes = fromHex(signature);
+			if (!sigBytes) {
+				return { valid: false, reason: "invalid-signature" };
+			}
+
+			const message = encoder.encode(timestamp + rawBody);
+			const key = await getKey();
+
+			try {
+				const valid = await crypto.subtle.verify("Ed25519", key, sigBytes, message);
+				if (!valid) {
+					return { valid: false, reason: "invalid-signature" };
+				}
+				return { valid: true };
+			} catch {
+				return { valid: false, reason: "invalid-signature" };
+			}
+		},
+	};
+}

--- a/tests/providers/discord.test.ts
+++ b/tests/providers/discord.test.ts
@@ -1,0 +1,120 @@
+import { beforeAll, describe, expect, it } from "vitest";
+import { discord } from "../../src/providers/discord.js";
+import { generateDiscordSignature, generateEd25519KeyPair } from "../helpers/signatures.js";
+
+let PUBLIC_KEY: string;
+let PRIVATE_KEY: CryptoKey;
+let OTHER_PRIVATE_KEY: CryptoKey;
+const BODY = '{"type":1}';
+const TIMESTAMP = "1700000000";
+
+beforeAll(async () => {
+	const keyPair = await generateEd25519KeyPair();
+	PUBLIC_KEY = keyPair.publicKey;
+	PRIVATE_KEY = keyPair.privateKey;
+	const otherKeyPair = await generateEd25519KeyPair();
+	OTHER_PRIVATE_KEY = otherKeyPair.privateKey;
+});
+
+describe("discord provider", () => {
+	it("P1: verifies valid signature", async () => {
+		const provider = discord({ publicKey: PUBLIC_KEY });
+		const signature = await generateDiscordSignature(BODY, TIMESTAMP, PRIVATE_KEY);
+		const result = await provider.verify({
+			rawBody: BODY,
+			headers: new Headers({
+				"X-Signature-Ed25519": signature,
+				"X-Signature-Timestamp": TIMESTAMP,
+			}),
+		});
+		expect(result).toEqual({ valid: true });
+	});
+
+	it("P2: rejects tampered body", async () => {
+		const provider = discord({ publicKey: PUBLIC_KEY });
+		const signature = await generateDiscordSignature(BODY, TIMESTAMP, PRIVATE_KEY);
+		const result = await provider.verify({
+			rawBody: '{"type":2}',
+			headers: new Headers({
+				"X-Signature-Ed25519": signature,
+				"X-Signature-Timestamp": TIMESTAMP,
+			}),
+		});
+		expect(result).toEqual({ valid: false, reason: "invalid-signature" });
+	});
+
+	it("P3: rejects wrong key", async () => {
+		const provider = discord({ publicKey: PUBLIC_KEY });
+		const signature = await generateDiscordSignature(BODY, TIMESTAMP, OTHER_PRIVATE_KEY);
+		const result = await provider.verify({
+			rawBody: BODY,
+			headers: new Headers({
+				"X-Signature-Ed25519": signature,
+				"X-Signature-Timestamp": TIMESTAMP,
+			}),
+		});
+		expect(result).toEqual({ valid: false, reason: "invalid-signature" });
+	});
+
+	it("P4: rejects missing signature header", async () => {
+		const provider = discord({ publicKey: PUBLIC_KEY });
+		const result = await provider.verify({
+			rawBody: BODY,
+			headers: new Headers({
+				"X-Signature-Timestamp": TIMESTAMP,
+			}),
+		});
+		expect(result).toEqual({ valid: false, reason: "missing-signature" });
+	});
+
+	it("rejects missing timestamp header", async () => {
+		const provider = discord({ publicKey: PUBLIC_KEY });
+		const signature = await generateDiscordSignature(BODY, TIMESTAMP, PRIVATE_KEY);
+		const result = await provider.verify({
+			rawBody: BODY,
+			headers: new Headers({
+				"X-Signature-Ed25519": signature,
+			}),
+		});
+		expect(result).toEqual({ valid: false, reason: "missing-signature" });
+	});
+
+	it("P5: verifies empty body", async () => {
+		const provider = discord({ publicKey: PUBLIC_KEY });
+		const signature = await generateDiscordSignature("", TIMESTAMP, PRIVATE_KEY);
+		const result = await provider.verify({
+			rawBody: "",
+			headers: new Headers({
+				"X-Signature-Ed25519": signature,
+				"X-Signature-Timestamp": TIMESTAMP,
+			}),
+		});
+		expect(result).toEqual({ valid: true });
+	});
+
+	it("P6: verifies multibyte body", async () => {
+		const provider = discord({ publicKey: PUBLIC_KEY });
+		const body = '{"content":"こんにちは"}';
+		const signature = await generateDiscordSignature(body, TIMESTAMP, PRIVATE_KEY);
+		const result = await provider.verify({
+			rawBody: body,
+			headers: new Headers({
+				"X-Signature-Ed25519": signature,
+				"X-Signature-Timestamp": TIMESTAMP,
+			}),
+		});
+		expect(result).toEqual({ valid: true });
+	});
+
+	it("rejects invalid hex in signature", async () => {
+		const provider = discord({ publicKey: PUBLIC_KEY });
+		const result = await provider.verify({
+			rawBody: BODY,
+			headers: new Headers({
+				"X-Signature-Ed25519": "not-valid-hex!!!",
+				"X-Signature-Timestamp": TIMESTAMP,
+			}),
+		});
+		expect(result).toEqual({ valid: false, reason: "invalid-signature" });
+	});
+});

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -9,6 +9,7 @@ export default defineConfig({
 		"providers/shopify": "src/providers/shopify.ts",
 		"providers/twilio": "src/providers/twilio.ts",
 		"providers/line": "src/providers/line.ts",
+		"providers/discord": "src/providers/discord.ts",
 	},
 	format: ["esm", "cjs"],
 	dts: true,


### PR DESCRIPTION
Closes #29

## Summary
- Add `src/providers/discord.ts` — Ed25519 signature verification using Web Crypto API
- Add `tests/providers/discord.test.ts` — P1-P6 + missing timestamp + invalid hex (8 tests)
- Add Ed25519 key pair generation and signing helpers to `tests/helpers/signatures.ts`
- Add subpath export: `hono-webhook-verify/providers/discord`

First asymmetric provider — uses `crypto.subtle.verify` with Ed25519 instead of HMAC.

## Test plan
- [x] 96 tests pass (88 existing + 8 new Discord tests)
- [x] Lint, typecheck, and build pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)