### PR TITLE
Add Standard Webhooks (svix-compatible) provider

### DIFF
--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -168,7 +168,7 @@ TDD で進める。テスト → 実装 → リファクタの順。
 ## Stretch Goals
 
 - [x] LINE Provider
-- [ ] Discord Provider
+- [x] Discord Provider
 - [ ] PayPal Provider
 - [ ] Standard Webhooks (svix 互換) Provider
 - [ ] プロバイダー自動検出（ヘッダーからプロバイダーを推定）

--- a/package.json
+++ b/package.json
@@ -86,6 +86,16 @@
 				"types": "./dist/providers/discord.d.cts",
 				"default": "./dist/providers/discord.cjs"
 			}
+		},
+		"./providers/standard-webhooks": {
+			"import": {
+				"types": "./dist/providers/standard-webhooks.d.ts",
+				"default": "./dist/providers/standard-webhooks.js"
+			},
+			"require": {
+				"types": "./dist/providers/standard-webhooks.d.cts",
+				"default": "./dist/providers/standard-webhooks.cjs"
+			}
 		}
 	},
 	"sideEffects": false,

--- a/src/crypto.ts
+++ b/src/crypto.ts
@@ -3,12 +3,13 @@ const encoder = new TextEncoder();
 /** Compute HMAC signature using Web Crypto API */
 export async function hmac(
 	algorithm: "SHA-256" | "SHA-1",
-	secret: string,
+	secret: string | ArrayBuffer,
 	data: string,
 ): Promise<ArrayBuffer> {
+	const keyData = typeof secret === "string" ? encoder.encode(secret) : secret;
 	const key = await crypto.subtle.importKey(
 		"raw",
-		encoder.encode(secret),
+		keyData,
 		{ name: "HMAC", hash: algorithm },
 		false,
 		["sign"],

--- a/src/providers/standard-webhooks.ts
+++ b/src/providers/standard-webhooks.ts
@@ -1,0 +1,57 @@
+import { fromBase64, hmac, timingSafeEqual } from "../crypto.js";
+import type { WebhookProvider } from "./types.js";
+
+interface StandardWebhooksOptions {
+	secret: string;
+	/** Timestamp tolerance in seconds (default: 300 = 5 minutes) */
+	tolerance?: number;
+}
+
+export function standardWebhooks(options: StandardWebhooksOptions): WebhookProvider {
+	const { tolerance = 300 } = options;
+	// Strip whsec_ prefix if present
+	const base64Key = options.secret.startsWith("whsec_") ? options.secret.slice(6) : options.secret;
+	const keyBytes = fromBase64(base64Key);
+	if (!keyBytes) {
+		throw new Error("standard-webhooks: secret must be valid base64 (with optional whsec_ prefix)");
+	}
+
+	return {
+		name: "standard-webhooks",
+		async verify({ rawBody, headers }) {
+			const msgId = headers.get("webhook-id");
+			const timestamp = headers.get("webhook-timestamp");
+			const signatureHeader = headers.get("webhook-signature");
+
+			if (!msgId || !timestamp || !signatureHeader) {
+				return { valid: false, reason: "missing-signature" };
+			}
+
+			const ts = Number(timestamp);
+			if (!Number.isFinite(ts) || ts <= 0) {
+				return { valid: false, reason: "missing-signature" };
+			}
+			const now = Math.floor(Date.now() / 1000);
+			if (Math.abs(now - ts) > tolerance) {
+				return { valid: false, reason: "timestamp-expired" };
+			}
+
+			const signedContent = `${msgId}.${timestamp}.${rawBody}`;
+			const expected = await hmac("SHA-256", keyBytes, signedContent);
+
+			// Support space-separated signatures for key rotation
+			const signatures = signatureHeader.split(" ");
+			const matched = signatures.some((sig) => {
+				if (!sig.startsWith("v1,")) return false;
+				const received = fromBase64(sig.slice(3));
+				return received !== null && timingSafeEqual(expected, received);
+			});
+
+			if (!matched) {
+				return { valid: false, reason: "invalid-signature" };
+			}
+
+			return { valid: true };
+		},
+	};
+}

--- a/tests/providers/standard-webhooks.test.ts
+++ b/tests/providers/standard-webhooks.test.ts
@@ -1,0 +1,225 @@
+import { describe, expect, it } from "vitest";
+import { standardWebhooks } from "../../src/providers/standard-webhooks.js";
+import { generateStandardWebhooksSignature } from "../helpers/signatures.js";
+
+// Generate a 32-byte key encoded as base64 for testing
+const SECRET_BASE64 = btoa(String.fromCharCode(...new Uint8Array(32).fill(42)));
+const SECRET = `whsec_${SECRET_BASE64}`;
+const WRONG_SECRET_BASE64 = btoa(String.fromCharCode(...new Uint8Array(32).fill(99)));
+const WRONG_SECRET = `whsec_${WRONG_SECRET_BASE64}`;
+const MSG_ID = "msg_test123";
+const BODY = '{"type":"event.created"}';
+
+describe("standard-webhooks provider", () => {
+	it("P1: verifies valid signature", async () => {
+		const provider = standardWebhooks({ secret: SECRET });
+		const { signature, timestamp } = await generateStandardWebhooksSignature(
+			BODY,
+			SECRET_BASE64,
+			MSG_ID,
+		);
+		const result = await provider.verify({
+			rawBody: BODY,
+			headers: new Headers({
+				"webhook-id": MSG_ID,
+				"webhook-timestamp": String(timestamp),
+				"webhook-signature": signature,
+			}),
+		});
+		expect(result).toEqual({ valid: true });
+	});
+
+	it("P2: rejects tampered body", async () => {
+		const provider = standardWebhooks({ secret: SECRET });
+		const { signature, timestamp } = await generateStandardWebhooksSignature(
+			BODY,
+			SECRET_BASE64,
+			MSG_ID,
+		);
+		const result = await provider.verify({
+			rawBody: '{"type":"tampered"}',
+			headers: new Headers({
+				"webhook-id": MSG_ID,
+				"webhook-timestamp": String(timestamp),
+				"webhook-signature": signature,
+			}),
+		});
+		expect(result).toEqual({ valid: false, reason: "invalid-signature" });
+	});
+
+	it("P3: rejects wrong secret", async () => {
+		const provider = standardWebhooks({ secret: WRONG_SECRET });
+		const { signature, timestamp } = await generateStandardWebhooksSignature(
+			BODY,
+			SECRET_BASE64,
+			MSG_ID,
+		);
+		const result = await provider.verify({
+			rawBody: BODY,
+			headers: new Headers({
+				"webhook-id": MSG_ID,
+				"webhook-timestamp": String(timestamp),
+				"webhook-signature": signature,
+			}),
+		});
+		expect(result).toEqual({ valid: false, reason: "invalid-signature" });
+	});
+
+	it("P4: rejects missing signature header", async () => {
+		const provider = standardWebhooks({ secret: SECRET });
+		const result = await provider.verify({
+			rawBody: BODY,
+			headers: new Headers({
+				"webhook-id": MSG_ID,
+				"webhook-timestamp": "1700000000",
+			}),
+		});
+		expect(result).toEqual({ valid: false, reason: "missing-signature" });
+	});
+
+	it("rejects missing webhook-id", async () => {
+		const provider = standardWebhooks({ secret: SECRET });
+		const { signature, timestamp } = await generateStandardWebhooksSignature(
+			BODY,
+			SECRET_BASE64,
+			MSG_ID,
+		);
+		const result = await provider.verify({
+			rawBody: BODY,
+			headers: new Headers({
+				"webhook-timestamp": String(timestamp),
+				"webhook-signature": signature,
+			}),
+		});
+		expect(result).toEqual({ valid: false, reason: "missing-signature" });
+	});
+
+	it("rejects missing timestamp", async () => {
+		const provider = standardWebhooks({ secret: SECRET });
+		const { signature } = await generateStandardWebhooksSignature(BODY, SECRET_BASE64, MSG_ID);
+		const result = await provider.verify({
+			rawBody: BODY,
+			headers: new Headers({
+				"webhook-id": MSG_ID,
+				"webhook-signature": signature,
+			}),
+		});
+		expect(result).toEqual({ valid: false, reason: "missing-signature" });
+	});
+
+	it("P5: verifies empty body", async () => {
+		const provider = standardWebhooks({ secret: SECRET });
+		const { signature, timestamp } = await generateStandardWebhooksSignature(
+			"",
+			SECRET_BASE64,
+			MSG_ID,
+		);
+		const result = await provider.verify({
+			rawBody: "",
+			headers: new Headers({
+				"webhook-id": MSG_ID,
+				"webhook-timestamp": String(timestamp),
+				"webhook-signature": signature,
+			}),
+		});
+		expect(result).toEqual({ valid: true });
+	});
+
+	it("P6: verifies multibyte body", async () => {
+		const provider = standardWebhooks({ secret: SECRET });
+		const body = '{"text":"こんにちは"}';
+		const { signature, timestamp } = await generateStandardWebhooksSignature(
+			body,
+			SECRET_BASE64,
+			MSG_ID,
+		);
+		const result = await provider.verify({
+			rawBody: body,
+			headers: new Headers({
+				"webhook-id": MSG_ID,
+				"webhook-timestamp": String(timestamp),
+				"webhook-signature": signature,
+			}),
+		});
+		expect(result).toEqual({ valid: true });
+	});
+
+	it("T2: rejects expired timestamp", async () => {
+		const provider = standardWebhooks({ secret: SECRET, tolerance: 300 });
+		const pastTimestamp = Math.floor(Date.now() / 1000) - 360;
+		const { signature } = await generateStandardWebhooksSignature(
+			BODY,
+			SECRET_BASE64,
+			MSG_ID,
+			pastTimestamp,
+		);
+		const result = await provider.verify({
+			rawBody: BODY,
+			headers: new Headers({
+				"webhook-id": MSG_ID,
+				"webhook-timestamp": String(pastTimestamp),
+				"webhook-signature": signature,
+			}),
+		});
+		expect(result).toEqual({ valid: false, reason: "timestamp-expired" });
+	});
+
+	it("T3: custom tolerance", async () => {
+		const provider = standardWebhooks({ secret: SECRET, tolerance: 60 });
+		const pastTimestamp = Math.floor(Date.now() / 1000) - 120;
+		const { signature } = await generateStandardWebhooksSignature(
+			BODY,
+			SECRET_BASE64,
+			MSG_ID,
+			pastTimestamp,
+		);
+		const result = await provider.verify({
+			rawBody: BODY,
+			headers: new Headers({
+				"webhook-id": MSG_ID,
+				"webhook-timestamp": String(pastTimestamp),
+				"webhook-signature": signature,
+			}),
+		});
+		expect(result).toEqual({ valid: false, reason: "timestamp-expired" });
+	});
+
+	it("supports multiple signatures (key rotation)", async () => {
+		const provider = standardWebhooks({ secret: SECRET });
+		const { signature: sig1, timestamp } = await generateStandardWebhooksSignature(
+			BODY,
+			SECRET_BASE64,
+			MSG_ID,
+		);
+		// Prepend an invalid signature — the valid one should still match
+		const combinedSig = `v1,invalid_base64_sig ${sig1}`;
+		const result = await provider.verify({
+			rawBody: BODY,
+			headers: new Headers({
+				"webhook-id": MSG_ID,
+				"webhook-timestamp": String(timestamp),
+				"webhook-signature": combinedSig,
+			}),
+		});
+		expect(result).toEqual({ valid: true });
+	});
+
+	it("strips whsec_ prefix from secret", async () => {
+		// Also works if someone passes just the base64 without prefix
+		const provider = standardWebhooks({ secret: SECRET_BASE64 });
+		const { signature, timestamp } = await generateStandardWebhooksSignature(
+			BODY,
+			SECRET_BASE64,
+			MSG_ID,
+		);
+		const result = await provider.verify({
+			rawBody: BODY,
+			headers: new Headers({
+				"webhook-id": MSG_ID,
+				"webhook-timestamp": String(timestamp),
+				"webhook-signature": signature,
+			}),
+		});
+		expect(result).toEqual({ valid: true });
+	});
+});

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -10,6 +10,7 @@ export default defineConfig({
 		"providers/twilio": "src/providers/twilio.ts",
 		"providers/line": "src/providers/line.ts",
 		"providers/discord": "src/providers/discord.ts",
+		"providers/standard-webhooks": "src/providers/standard-webhooks.ts",
 	},
 	format: ["esm", "cjs"],
 	dts: true,


### PR DESCRIPTION
Closes #31

## Summary
- Add `src/providers/standard-webhooks.ts` — Standard Webhooks spec implementation
  - HMAC-SHA256 with base64-decoded key material (`whsec_` prefix support)
  - `webhook-id.webhook-timestamp.body` signed content format
  - Space-separated signature support for key rotation
  - Timestamp tolerance with NaN guard
- Add `tests/providers/standard-webhooks.test.ts` — P1-P6, T2-T3, key rotation, prefix stripping (12 tests)
- Extend `hmac()` in `src/crypto.ts` to accept `ArrayBuffer` keys for binary key material
- Add subpath export: `hono-webhook-verify/providers/standard-webhooks`

## Test plan
- [x] 108 tests pass (96 existing + 12 new)
- [x] Lint, typecheck, and build pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)