### PR TITLE
Add provider auto-detection from headers

### DIFF
--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -170,6 +170,6 @@ TDD で進める。テスト → 実装 → リファクタの順。
 - [x] LINE Provider
 - [x] Discord Provider
 - [ ] PayPal Provider
-- [ ] Standard Webhooks (svix 互換) Provider
+- [x] Standard Webhooks (svix 互換) Provider
 - [ ] プロバイダー自動検出（ヘッダーからプロバイダーを推定）
 - [x] CONTRIBUTING.md — プロバイダー追加ガイド（コントリビューション誘引）

--- a/src/detect.ts
+++ b/src/detect.ts
@@ -1,0 +1,28 @@
+export type ProviderName =
+	| "stripe"
+	| "github"
+	| "slack"
+	| "shopify"
+	| "twilio"
+	| "line"
+	| "discord"
+	| "standard-webhooks";
+
+const detectors: Array<{ name: ProviderName; detect: (h: Headers) => boolean }> = [
+	{ name: "stripe", detect: (h) => h.has("Stripe-Signature") },
+	{ name: "github", detect: (h) => h.has("X-Hub-Signature-256") },
+	{ name: "slack", detect: (h) => h.has("X-Slack-Signature") },
+	{ name: "shopify", detect: (h) => h.has("X-Shopify-Hmac-Sha256") },
+	{ name: "twilio", detect: (h) => h.has("X-Twilio-Signature") },
+	{ name: "line", detect: (h) => h.has("X-Line-Signature") },
+	{ name: "discord", detect: (h) => h.has("X-Signature-Ed25519") },
+	{ name: "standard-webhooks", detect: (h) => h.has("webhook-signature") },
+];
+
+/** Detect the webhook provider from request headers. Returns null if unknown. */
+export function detectProvider(headers: Headers): ProviderName | null {
+	for (const { name, detect } of detectors) {
+		if (detect(headers)) return name;
+	}
+	return null;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,7 @@
 export { webhookVerify } from "./middleware.js";
 export { defineProvider } from "./define-provider.js";
+export { detectProvider } from "./detect.js";
+export type { ProviderName } from "./detect.js";
 export type {
 	WebhookVerifyOptions,
 	WebhookVerifyError,

--- a/tests/detect.test.ts
+++ b/tests/detect.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import { detectProvider } from "../src/detect.js";
+
+describe("detectProvider", () => {
+	it("detects Stripe", () => {
+		const headers = new Headers({ "Stripe-Signature": "t=123,v1=abc" });
+		expect(detectProvider(headers)).toBe("stripe");
+	});
+
+	it("detects GitHub", () => {
+		const headers = new Headers({ "X-Hub-Signature-256": "sha256=abc" });
+		expect(detectProvider(headers)).toBe("github");
+	});
+
+	it("detects Slack", () => {
+		const headers = new Headers({
+			"X-Slack-Signature": "v0=abc",
+			"X-Slack-Request-Timestamp": "123",
+		});
+		expect(detectProvider(headers)).toBe("slack");
+	});
+
+	it("detects Shopify", () => {
+		const headers = new Headers({ "X-Shopify-Hmac-Sha256": "abc" });
+		expect(detectProvider(headers)).toBe("shopify");
+	});
+
+	it("detects Twilio", () => {
+		const headers = new Headers({ "X-Twilio-Signature": "abc" });
+		expect(detectProvider(headers)).toBe("twilio");
+	});
+
+	it("detects LINE", () => {
+		const headers = new Headers({ "X-Line-Signature": "abc" });
+		expect(detectProvider(headers)).toBe("line");
+	});
+
+	it("detects Discord", () => {
+		const headers = new Headers({
+			"X-Signature-Ed25519": "abc",
+			"X-Signature-Timestamp": "123",
+		});
+		expect(detectProvider(headers)).toBe("discord");
+	});
+
+	it("detects Standard Webhooks", () => {
+		const headers = new Headers({
+			"webhook-id": "msg_123",
+			"webhook-signature": "v1,abc",
+			"webhook-timestamp": "123",
+		});
+		expect(detectProvider(headers)).toBe("standard-webhooks");
+	});
+
+	it("returns null for unknown headers", () => {
+		const headers = new Headers({ "X-Custom-Sig": "abc" });
+		expect(detectProvider(headers)).toBeNull();
+	});
+
+	it("returns null for empty headers", () => {
+		const headers = new Headers();
+		expect(detectProvider(headers)).toBeNull();
+	});
+});


### PR DESCRIPTION
Closes #33

## Summary
- Add `src/detect.ts` — `detectProvider()` identifies webhook source from request headers
- Supports all 8 built-in providers: Stripe, GitHub, Slack, Shopify, Twilio, LINE, Discord, Standard Webhooks
- Returns `null` for unknown headers
- Exported from main index with `ProviderName` type

## Test plan
- [x] 118 tests pass (108 existing + 10 new detection tests)
- [x] Lint, typecheck, and build pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)