### PR TITLE
Export provider Options interfaces for TypeScript users

### DIFF
--- a/src/providers/discord.ts
+++ b/src/providers/discord.ts
@@ -1,7 +1,7 @@
 import { fromHex } from "../crypto.js";
 import type { WebhookProvider } from "./types.js";
 
-interface DiscordOptions {
+export interface DiscordOptions {
 	publicKey: string;
 }
 

--- a/src/providers/github.ts
+++ b/src/providers/github.ts
@@ -1,7 +1,7 @@
 import { fromHex, hmac, timingSafeEqual } from "../crypto.js";
 import type { WebhookProvider } from "./types.js";
 
-interface GitHubOptions {
+export interface GitHubOptions {
 	secret: string;
 }
 

--- a/src/providers/line.ts
+++ b/src/providers/line.ts
@@ -1,7 +1,7 @@
 import { fromBase64, hmac, timingSafeEqual } from "../crypto.js";
 import type { WebhookProvider } from "./types.js";
 
-interface LineOptions {
+export interface LineOptions {
 	channelSecret: string;
 }
 

--- a/src/providers/shopify.ts
+++ b/src/providers/shopify.ts
@@ -1,7 +1,7 @@
 import { fromBase64, hmac, timingSafeEqual } from "../crypto.js";
 import type { WebhookProvider } from "./types.js";
 
-interface ShopifyOptions {
+export interface ShopifyOptions {
 	secret: string;
 }
 

--- a/src/providers/slack.ts
+++ b/src/providers/slack.ts
@@ -1,7 +1,7 @@
 import { fromHex, hmac, timingSafeEqual } from "../crypto.js";
 import type { WebhookProvider } from "./types.js";
 
-interface SlackOptions {
+export interface SlackOptions {
 	signingSecret: string;
 	/** Timestamp tolerance in seconds (default: 300 = 5 minutes) */
 	tolerance?: number;

--- a/src/providers/standard-webhooks.ts
+++ b/src/providers/standard-webhooks.ts
@@ -1,7 +1,7 @@
 import { fromBase64, hmac, timingSafeEqual } from "../crypto.js";
 import type { WebhookProvider } from "./types.js";
 
-interface StandardWebhooksOptions {
+export interface StandardWebhooksOptions {
 	secret: string;
 	/** Timestamp tolerance in seconds (default: 300 = 5 minutes) */
 	tolerance?: number;

--- a/src/providers/stripe.ts
+++ b/src/providers/stripe.ts
@@ -1,7 +1,7 @@
 import { fromHex, hmac, timingSafeEqual } from "../crypto.js";
 import type { WebhookProvider } from "./types.js";
 
-interface StripeOptions {
+export interface StripeOptions {
 	secret: string;
 	/** Timestamp tolerance in seconds (default: 300 = 5 minutes) */
 	tolerance?: number;

--- a/src/providers/twilio.ts
+++ b/src/providers/twilio.ts
@@ -1,7 +1,7 @@
 import { fromBase64, hmac, timingSafeEqual } from "../crypto.js";
 import type { WebhookProvider } from "./types.js";
 
-interface TwilioOptions {
+export interface TwilioOptions {
 	authToken: string;
 }
 


### PR DESCRIPTION
## Summary
- Export all provider `Options` interfaces (`StripeOptions`, `GitHubOptions`, `SlackOptions`, `ShopifyOptions`, `TwilioOptions`, `LineOptions`, `DiscordOptions`, `StandardWebhooksOptions`) so TypeScript users can reference them

Closes #36

## Test plan
- [x] All 118 tests pass
- [x] TypeScript type check passes
- [x] No runtime behavior changes (interface-only export)

🤖 Generated with [Claude Code](https://claude.com/claude-code)