### PR TITLE
Add missing keywords for LINE, Discord, Standard Webhooks

### DIFF
--- a/package.json
+++ b/package.json
@@ -122,6 +122,10 @@
 		"slack",
 		"shopify",
 		"twilio",
+		"line",
+		"discord",
+		"standard-webhooks",
+		"svix",
 		"cloudflare-workers",
 		"edge"
 	],


### PR DESCRIPTION
## Summary
- Add `line`, `discord`, `standard-webhooks`, `svix` to package.json keywords for better npm discoverability

Closes #38

## Test plan
- [x] All 118 tests pass
- [x] Metadata-only change, no runtime impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)