### PR TITLE
Fix middleware error detail to use human-readable messages

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -24,12 +24,17 @@ export function webhookVerify(options: WebhookVerifyOptions) {
 
 		if (!result.valid) {
 			const reason = result.reason ?? "invalid-signature";
+			const detailMessages: Record<string, string> = {
+				"missing-signature": "Required webhook signature header is missing",
+				"invalid-signature": "Signature verification failed",
+				"timestamp-expired": "Webhook timestamp is outside the allowed tolerance",
+			};
 			const errorFns: Record<string, typeof invalidSignature> = {
 				"missing-signature": missingSignature,
 				"timestamp-expired": timestampExpired,
 			};
 			const errorFn = errorFns[reason] ?? invalidSignature;
-			const error = errorFn(result.reason ?? "Signature verification failed");
+			const error = errorFn(detailMessages[reason] ?? "Signature verification failed");
 			if (onError) return onError(error, c);
 			return c.json(error, error.status as ContentfulStatusCode);
 		}

--- a/tests/middleware.test.ts
+++ b/tests/middleware.test.ts
@@ -109,7 +109,18 @@ describe("webhookVerify middleware", () => {
 		expect(await res.text()).toBe("github");
 	});
 
-	it("M8: custom onError returns custom response", async () => {
+	it("M8: error detail contains human-readable message, not reason code", async () => {
+		const app = createGitHubApp();
+		const res = await app.request("/webhook", {
+			method: "POST",
+			body: BODY,
+		});
+		const body = await res.json();
+		expect(body.detail).not.toBe("missing-signature");
+		expect(body.detail).toContain("missing");
+	});
+
+	it("M9: custom onError returns custom response", async () => {
 		const app = new Hono<{ Variables: WebhookVerifyVariables }>();
 		app.post(
 			"/webhook",


### PR DESCRIPTION
## Summary
- Map reason codes (`missing-signature`, `invalid-signature`, `timestamp-expired`) to human-readable detail messages instead of passing raw reason strings
- Add test (M8) to verify detail messages are not raw reason codes

Closes #40

## Test plan
- [x] All 119 tests pass (1 new)
- [x] TypeScript type check passes
- [x] New test M8 verifies detail is human-readable

🤖 Generated with [Claude Code](https://claude.com/claude-code)