### PR TITLE
Validate empty secrets at construction time in all HMAC providers

### DIFF
--- a/src/providers/line.ts
+++ b/src/providers/line.ts
@@ -8,6 +8,10 @@ export interface LineOptions {
 export function line(options: LineOptions): WebhookProvider {
 	const { channelSecret } = options;
 
+	if (!channelSecret) {
+		throw new Error("line: channelSecret must not be empty");
+	}
+
 	return {
 		name: "line",
 		async verify({ rawBody, headers }) {

--- a/src/providers/shopify.ts
+++ b/src/providers/shopify.ts
@@ -8,6 +8,10 @@ export interface ShopifyOptions {
 export function shopify(options: ShopifyOptions): WebhookProvider {
 	const { secret } = options;
 
+	if (!secret) {
+		throw new Error("shopify: secret must not be empty");
+	}
+
 	return {
 		name: "shopify",
 		async verify({ rawBody, headers }) {

--- a/src/providers/slack.ts
+++ b/src/providers/slack.ts
@@ -10,6 +10,10 @@ export interface SlackOptions {
 export function slack(options: SlackOptions): WebhookProvider {
 	const { signingSecret, tolerance = 300 } = options;
 
+	if (!signingSecret) {
+		throw new Error("slack: signingSecret must not be empty");
+	}
+
 	return {
 		name: "slack",
 		async verify({ rawBody, headers }) {

--- a/src/providers/stripe.ts
+++ b/src/providers/stripe.ts
@@ -10,6 +10,10 @@ export interface StripeOptions {
 export function stripe(options: StripeOptions): WebhookProvider {
 	const { secret, tolerance = 300 } = options;
 
+	if (!secret) {
+		throw new Error("stripe: secret must not be empty");
+	}
+
 	return {
 		name: "stripe",
 		async verify({ rawBody, headers }) {

--- a/src/providers/twilio.ts
+++ b/src/providers/twilio.ts
@@ -8,6 +8,10 @@ export interface TwilioOptions {
 export function twilio(options: TwilioOptions): WebhookProvider {
 	const { authToken } = options;
 
+	if (!authToken) {
+		throw new Error("twilio: authToken must not be empty");
+	}
+
 	return {
 		name: "twilio",
 		async verify({ rawBody, headers, url }) {

--- a/tests/providers/line.test.ts
+++ b/tests/providers/line.test.ts
@@ -26,6 +26,10 @@ describe("line provider", () => {
 		expect(result).toEqual({ valid: false, reason: "invalid-signature" });
 	});
 
+	it("throws on empty channelSecret", () => {
+		expect(() => line({ channelSecret: "" })).toThrow("channelSecret must not be empty");
+	});
+
 	it("P3: rejects wrong secret", async () => {
 		const provider = line({ channelSecret: SECRET });
 		const signature = await generateLineSignature(BODY, "wrong_secret");

--- a/tests/providers/shopify.test.ts
+++ b/tests/providers/shopify.test.ts
@@ -26,6 +26,10 @@ describe("shopify provider", () => {
 		expect(result).toEqual({ valid: false, reason: "invalid-signature" });
 	});
 
+	it("throws on empty secret", () => {
+		expect(() => shopify({ secret: "" })).toThrow("secret must not be empty");
+	});
+
 	it("rejects wrong secret", async () => {
 		const provider = shopify({ secret: SECRET });
 		const signature = await generateShopifySignature(BODY, "wrong_secret");

--- a/tests/providers/slack.test.ts
+++ b/tests/providers/slack.test.ts
@@ -45,6 +45,10 @@ describe("slack provider", () => {
 		expect(result).toEqual({ valid: false, reason: "invalid-signature" });
 	});
 
+	it("throws on empty signingSecret", () => {
+		expect(() => slack({ signingSecret: "" })).toThrow("signingSecret must not be empty");
+	});
+
 	it("rejects missing signature header", async () => {
 		const provider = slack({ signingSecret: SECRET });
 		const result = await provider.verify({

--- a/tests/providers/stripe.test.ts
+++ b/tests/providers/stripe.test.ts
@@ -123,6 +123,10 @@ describe("stripe provider", () => {
 		expect(result).toEqual({ valid: false, reason: "missing-signature" });
 	});
 
+	it("throws on empty secret", () => {
+		expect(() => stripe({ secret: "" })).toThrow("secret must not be empty");
+	});
+
 	it("rejects malformed header without t= or v1=", async () => {
 		const provider = stripe({ secret: SECRET });
 		const result = await provider.verify({

--- a/tests/providers/twilio.test.ts
+++ b/tests/providers/twilio.test.ts
@@ -67,6 +67,10 @@ describe("twilio provider", () => {
 		expect(result).toEqual({ valid: false, reason: "invalid-signature" });
 	});
 
+	it("throws on empty authToken", () => {
+		expect(() => twilio({ authToken: "" })).toThrow("authToken must not be empty");
+	});
+
 	it("rejects missing signature header", async () => {
 		const provider = twilio({ authToken: AUTH_TOKEN });
 		const result = await provider.verify({


### PR DESCRIPTION
## Summary
- Add empty secret/key validation at construction time in Stripe, Shopify, Slack, LINE, and Twilio providers
- Matches existing pattern in GitHub provider (throws Error for empty secrets)
- Prevents silently computing a valid HMAC with an empty secret that attackers could forge

Closes #44

## Test plan
- [x] All 129 tests pass (5 new)
- [x] TypeScript type check passes
- [x] Each provider throws descriptive error for empty secret

🤖 Generated with [Claude Code](https://claude.com/claude-code)