### PR TITLE
Achieve 100% test coverage and re-enable coverage in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
 
       - run: pnpm typecheck
 
-      - run: pnpm test
+      - run: pnpm vitest run --coverage
 
       - run: pnpm build
 

--- a/src/providers/twilio.ts
+++ b/src/providers/twilio.ts
@@ -26,14 +26,14 @@ export function twilio(options: TwilioOptions): WebhookProvider {
 
 			// Twilio signs: URL + sorted POST parameters
 			const params = new URLSearchParams(rawBody);
-			const sortedKeys: string[] = [];
-			params.forEach((_value, key) => {
-				sortedKeys.push(key);
+			const entries: [string, string][] = [];
+			params.forEach((value, key) => {
+				entries.push([key, value]);
 			});
-			sortedKeys.sort();
+			entries.sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0));
 			let dataToSign = url;
-			for (const key of sortedKeys) {
-				dataToSign += key + (params.get(key) ?? "");
+			for (const [key, value] of entries) {
+				dataToSign += key + value;
 			}
 
 			const expected = await hmac("SHA-1", authToken, dataToSign);

--- a/tests/errors.test.ts
+++ b/tests/errors.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import {
+	bodyReadFailed,
+	invalidSignature,
+	missingSignature,
+	timestampExpired,
+} from "../src/errors.js";
+
+describe("error constructors", () => {
+	it("bodyReadFailed returns RFC 9457 problem detail", () => {
+		const error = bodyReadFailed("Could not read the request body");
+		expect(error).toEqual({
+			type: "https://hono-webhook-verify.dev/errors/body-read-failed",
+			title: "Failed to read request body",
+			status: 400,
+			detail: "Could not read the request body",
+		});
+	});
+
+	it("missingSignature returns 401 with correct type", () => {
+		const error = missingSignature("sig missing");
+		expect(error.status).toBe(401);
+		expect(error.type).toContain("missing-signature");
+	});
+
+	it("invalidSignature returns 401 with correct type", () => {
+		const error = invalidSignature("sig invalid");
+		expect(error.status).toBe(401);
+		expect(error.type).toContain("invalid-signature");
+	});
+
+	it("timestampExpired returns 401 with correct type", () => {
+		const error = timestampExpired("ts expired");
+		expect(error.status).toBe(401);
+		expect(error.type).toContain("timestamp-expired");
+	});
+});

--- a/tests/providers/slack.test.ts
+++ b/tests/providers/slack.test.ts
@@ -161,4 +161,18 @@ describe("slack provider", () => {
 		});
 		expect(result).toEqual({ valid: false, reason: "missing-signature" });
 	});
+
+	it("rejects signature without v0= prefix as invalid", async () => {
+		const provider = slack({ signingSecret: SECRET });
+		const { timestamp } = await generateSlackSignature(BODY, SECRET);
+		// Send raw hex without v0= prefix — fromHex will succeed but HMAC won't match
+		const result = await provider.verify({
+			rawBody: BODY,
+			headers: new Headers({
+				"X-Slack-Signature": "aa".repeat(32),
+				"X-Slack-Request-Timestamp": String(timestamp),
+			}),
+		});
+		expect(result).toEqual({ valid: false, reason: "invalid-signature" });
+	});
 });

--- a/tests/providers/twilio.test.ts
+++ b/tests/providers/twilio.test.ts
@@ -101,4 +101,18 @@ describe("twilio provider", () => {
 		});
 		expect(result).toEqual({ valid: true });
 	});
+
+	it("handles duplicate parameter keys", async () => {
+		const provider = twilio({ authToken: AUTH_TOKEN });
+		// URLSearchParams with duplicate keys: "a=1&a=2"
+		// forEach yields two entries with key "a", sort comparator returns 0
+		const body = "a=1&a=2";
+		const signature = await generateTwilioSignature(URL, {}, AUTH_TOKEN, body);
+		const result = await provider.verify({
+			rawBody: body,
+			headers: new Headers({ "X-Twilio-Signature": signature }),
+			url: URL,
+		});
+		expect(result).toEqual({ valid: true });
+	});
 });


### PR DESCRIPTION
## Summary

Closes #51

- Added 19 tests covering all previously uncovered error paths, edge cases, and branch conditions (148 total tests, up from 129)
- Refactored `twilio.ts` to eliminate an unreachable `?? ""` branch by collecting key-value pairs directly from `URLSearchParams.forEach`
- Re-enabled `pnpm vitest run --coverage` in CI with 100% thresholds for statements, branches, functions, and lines

### New tests by file

| File | Tests added | What they cover |
|---|---|---|
| `tests/errors.test.ts` | 4 | All error constructor functions including `bodyReadFailed` |
| `tests/middleware.test.ts` | 4 | Body read failure (catch block), missing reason fallback, unknown reason, onError with body failure |
| `tests/providers/discord.test.ts` | 3 | Invalid hex publicKey, verify catch block (mocked), cached key path |
| `tests/providers/slack.test.ts` | 1 | Signature without `v0=` prefix |
| `tests/providers/standard-webhooks.test.ts` | 4 | Invalid base64 secret, zero/negative/non-numeric timestamps, non-v1 signature prefix |
| `tests/providers/twilio.test.ts` | 1 | Duplicate parameter keys (sort comparator equality) |
| `tests/crypto.test.ts` | 1 | `timingSafeEqual` native `subtle.timingSafeEqual` delegation (mocked) |
| `tests/helpers/signatures.ts` | - | Extended Twilio helper to support raw body signing |

## Test plan

- [x] `pnpm vitest run --coverage` passes with 100% on all 4 metrics
- [x] `pnpm lint` passes
- [x] `pnpm typecheck` passes
- [x] `pnpm build` succeeds
- [ ] CI passes on Node 20, 22, 24

🤖 Generated with [Claude Code](https://claude.com/claude-code)