### PR TITLE
Improve test quality: boundary values, isolation, and deduplication

### DIFF
--- a/tests/detect.test.ts
+++ b/tests/detect.test.ts
@@ -61,4 +61,13 @@ describe("detectProvider", () => {
 		const headers = new Headers();
 		expect(detectProvider(headers)).toBeNull();
 	});
+
+	it("returns first matching provider when multiple headers are present", () => {
+		// Stripe is first in the detector array, so it wins over GitHub
+		const headers = new Headers({
+			"Stripe-Signature": "t=123,v1=abc",
+			"X-Hub-Signature-256": "sha256=abc",
+		});
+		expect(detectProvider(headers)).toBe("stripe");
+	});
 });

--- a/tests/helpers/constants.ts
+++ b/tests/helpers/constants.ts
@@ -1,0 +1,5 @@
+/** Default timestamp tolerance used by providers (seconds) */
+export const DEFAULT_TOLERANCE_S = 300;
+
+/** Offset that exceeds the default tolerance — used to test expiry rejection */
+export const EXPIRED_OFFSET_S = DEFAULT_TOLERANCE_S + 60;

--- a/tests/middleware.test.ts
+++ b/tests/middleware.test.ts
@@ -5,6 +5,7 @@ import { webhookVerify } from "../src/middleware.js";
 import { github } from "../src/providers/github.js";
 import { stripe } from "../src/providers/stripe.js";
 import type { WebhookVerifyVariables } from "../src/types.js";
+import { EXPIRED_OFFSET_S } from "./helpers/constants.js";
 import { generateGitHubSignature, generateStripeSignature } from "./helpers/signatures.js";
 
 const GITHUB_SECRET = "gh_test_secret";
@@ -76,7 +77,7 @@ describe("webhookVerify middleware", () => {
 
 	it("M4: rejects expired timestamp with 401 (Stripe)", async () => {
 		const app = createStripeApp();
-		const sixMinAgo = Math.floor(Date.now() / 1000) - 360;
+		const sixMinAgo = Math.floor(Date.now() / 1000) - EXPIRED_OFFSET_S;
 		const { header } = await generateStripeSignature(BODY, STRIPE_SECRET, sixMinAgo);
 		const res = await app.request("/webhook", {
 			method: "POST",

--- a/tests/providers/discord.test.ts
+++ b/tests/providers/discord.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import { beforeAll, describe, expect, it, vi } from "vitest";
 import { discord } from "../../src/providers/discord.js";
 import { generateDiscordSignature, generateEd25519KeyPair } from "../helpers/signatures.js";
 


### PR DESCRIPTION
## Summary

Closes #53

Code review identified 11 test quality issues. This PR addresses all of them while maintaining 100% coverage (159 tests, up from 148).

### Changes

**Test correctness fixes:**
- Fix zero/negative timestamp tests in slack and standard-webhooks to generate signatures for the tested timestamp value, properly isolating the `ts <= 0` guard
- Replace `fromHexSimple` (unsafe duplicate) with imported `fromHex` in define-provider.test.ts

**Boundary value tests added:**
- `tolerance: 0` rejects 1-second-old timestamps (stripe, slack, standard-webhooks)
- Exact tolerance boundary (`tolerance: 60`, timestamp 60s ago) is accepted
- Empty signature values: `v1=` (stripe), `v1,` (standard-webhooks)
- `detectProvider` priority when multiple provider headers are present

**Missing path coverage:**
- `timingSafeEqual` XOR fallback correctness (with `subtle.timingSafeEqual` removed)
- `hmac` with `ArrayBuffer` secret (previously only tested via string path)
- `standard-webhooks` with default tolerance (previously always explicit)

**Code quality:**
- Extract `DEFAULT_TOLERANCE_S`/`EXPIRED_OFFSET_S` to `tests/helpers/constants.ts`
- Remove unused `afterEach` imports from discord.test.ts and crypto.test.ts

## Test plan

- [x] `pnpm vitest run --coverage` passes with 100% on all 4 metrics (159 tests)
- [x] `pnpm lint` passes
- [x] `pnpm typecheck` passes
- [x] `pnpm build` succeeds
- [ ] CI passes on Node 20, 22, 24

🤖 Generated with [Claude Code](https://claude.com/claude-code)