### PR TITLE
Fix misleading onError example and translate docs to English

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,14 +221,11 @@ webhookVerify({
 ```
 
 ```ts
-// Skip verification in development
+// Custom error response with logging
 webhookVerify({
   provider: stripe({ secret: process.env.STRIPE_WEBHOOK_SECRET! }),
   onError: (error, c) => {
-    if (process.env.NODE_ENV === "development") {
-      console.warn("Skipping webhook verification in development");
-      return; // falls through to handler
-    }
+    console.error("Webhook verification failed:", error.detail);
     return c.json({ error: error.title }, error.status as 400 | 401);
   },
 });

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,52 +1,52 @@
 # hono-webhook-verify
 
-主要 SaaS の Webhook 署名検証ミドルウェア for Hono。
-プロバイダーごとの HMAC 差異を吸収し、1行で導入できる。
+Webhook signature verification middleware for Hono, covering major SaaS providers.
+Absorbs per-provider HMAC differences so you can add verification in one line.
 
 ## Why
 
-- Webhook を受け取る API は署名検証が必須。しかしプロバイダーごとにヘッダー名、アルゴリズム、エンコーディング、タイムスタンプ形式がすべて異なる
-- 毎回公式ドキュメントを読んで実装するのは非効率で、実装ミスによるセキュリティリスクがある
-- Express 向けにはプロバイダー個別のライブラリはあるが、**統一的な Webhook 検証ミドルウェアは Hono にゼロ**
-- LINE Bot 専用 (`@nakanoaas/hono-linebot-middleware`) のみ存在
+- Any API that receives webhooks must verify signatures, yet every provider uses different header names, algorithms, encodings, and timestamp formats
+- Re-implementing verification from each provider's docs is error-prone and a security risk
+- Express has per-provider libraries, but **there is no unified webhook verification middleware for Hono**
+- Only `@nakanoaas/hono-linebot-middleware` (LINE-only) existed
 
 ## Positioning
 
-> Hono で Webhook エンドポイントを作る開発者が、プロバイダーを指定するだけで
-> 署名検証を完了できるミドルウェア。Web Crypto API ベースでエッジ環境対応。
+> A middleware that lets developers building webhook endpoints with Hono
+> complete signature verification just by specifying a provider. Web Crypto API-based, edge-ready.
 
 ## Competitive Landscape
 
-| アプローチ | Hono対応 | Edge対応 | 複数プロバイダー | 統一API |
-|-----------|---------|---------|----------------|---------|
-| 各プロバイダー公式SDK | No (Express/Node前提) | 一部のみ | 1つずつ個別 | No |
-| @nakanoaas/hono-linebot-middleware | Yes | Yes | LINE のみ | — |
-| svix/svix-webhooks | No | No | Standard Webhooks のみ | Yes |
-| **hono-webhook-verify** | **Yes** | **Yes** | **Stripe, GitHub, Slack, Shopify, Twilio...** | **Yes** |
+| Approach | Hono support | Edge support | Multi-provider | Unified API |
+|----------|-------------|-------------|----------------|-------------|
+| Provider SDKs | No (Express/Node assumed) | Partial | One at a time | No |
+| @nakanoaas/hono-linebot-middleware | Yes | Yes | LINE only | — |
+| svix/svix-webhooks | No | No | Standard Webhooks only | Yes |
+| **hono-webhook-verify** | **Yes** | **Yes** | **Stripe, GitHub, Slack, Shopify, Twilio, LINE, Discord, Standard Webhooks** | **Yes** |
 
 ## Differentiation
 
-1. **Hono ネイティブ** — `createMiddleware()` ベース、型安全なコンテキスト
-2. **Edge-first** — Web Crypto API のみ使用、Node.js crypto 不要
-3. **統一 API** — プロバイダーを切り替えてもミドルウェアの使い方は同一
-4. **ゼロ外部依存** — Hono 本体以外の依存なし
-5. **タイミングセーフ比較** — 定数時間比較でサイドチャネル攻撃を防止
-6. **プロバイダー追加が容易** — Provider インターフェース実装のみで対応可能
+1. **Hono-native** — Built on `createMiddleware()` with type-safe context
+2. **Edge-first** — Web Crypto API only, no Node.js crypto dependency
+3. **Unified API** — Same middleware usage regardless of provider
+4. **Zero external dependencies** — Only Hono as a peer dependency
+5. **Timing-safe comparison** — Constant-time comparison to prevent side-channel attacks
+6. **Easy provider addition** — Just implement the Provider interface
 
-## hono-idempotency からの横展開
+## Inspiration from hono-idempotency
 
-| プラクティス | hono-idempotency | hono-webhook-verify |
-|-------------|-----------------|-------------------|
-| Web Crypto API | フィンガープリント (SHA-256) | HMAC 署名検証 (SHA-256/SHA-1) |
-| サブパスエクスポート | Store アダプタ分離 | Provider アダプタ分離 |
-| ゼロ外部依存 | ✓ | ✓ |
-| createMiddleware() | ✓ | ✓ |
-| 型安全コンテキスト | `c.get('idempotencyKey')` | `c.get('webhookPayload')` |
-| RFC 9457 エラー | ✓ | ✓ |
-| Tooling | biome + TS strict + vitest + tsup | 同一 |
+| Practice | hono-idempotency | hono-webhook-verify |
+|----------|-----------------|-------------------|
+| Web Crypto API | Fingerprint (SHA-256) | HMAC signature verification (SHA-256/SHA-1) |
+| Subpath exports | Store adapter separation | Provider adapter separation |
+| Zero external deps | Yes | Yes |
+| createMiddleware() | Yes | Yes |
+| Type-safe context | `c.get('idempotencyKey')` | `c.get('webhookPayload')` |
+| RFC 9457 errors | Yes | Yes |
+| Tooling | biome + TS strict + vitest + tsup | Same |
 
 ## Success Metrics
 
-- 30日: npm 公開、Hono 公式 third-party middleware への PR 提出
-- 90日: GitHub 100+ stars、週間 500+ DL
-- 180日: 5+ プロバイダー対応、コミュニティ PR によるプロバイダー追加
+- 30 days: Published to npm, PR submitted to Hono official third-party middleware list
+- 90 days: 100+ GitHub stars, 500+ weekly downloads
+- 180 days: 5+ providers supported, community-contributed provider additions

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "hono-webhook-verify",
 	"version": "0.1.1",
-	"description": "Webhook signature verification middleware for Hono. Supports Stripe, GitHub, Slack, Shopify, Twilio and custom providers.",
+	"description": "Webhook signature verification middleware for Hono. Supports Stripe, GitHub, Slack, Shopify, Twilio, LINE, Discord, Standard Webhooks, and custom providers.",
 	"type": "module",
 	"main": "./dist/index.cjs",
 	"module": "./dist/index.js",


### PR DESCRIPTION
## Summary

- Remove unsafe `void`-return `onError` example from README that suggested bypassing webhook verification (fail-open anti-pattern identified by security review)
- Replace with safe `onError` example that always returns a `Response` (fail-closed)
- Translate all `docs/*.md` files from Japanese to English
- Update `package.json` description to include LINE, Discord, Standard Webhooks providers

Closes #56

## Test plan

- [x] All 159 tests pass
- [x] 100% code coverage maintained
- [x] lint, typecheck, build all pass
- [x] Security review confirmed `onError` must always return a Response (no void bypass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)