### PR TITLE
Fix Discord provider cachedKey race condition

### DIFF
--- a/src/providers/discord.ts
+++ b/src/providers/discord.ts
@@ -17,12 +17,13 @@ export function discord(options: DiscordOptions): WebhookProvider {
 	// Store in a typed variable so TypeScript narrows across the closure.
 	const keyBytes: ArrayBuffer = rawKey;
 
-	let cachedKey: CryptoKey | null = null;
+	let keyPromise: Promise<CryptoKey> | null = null;
 
-	async function getKey(): Promise<CryptoKey> {
-		if (cachedKey) return cachedKey;
-		cachedKey = await crypto.subtle.importKey("raw", keyBytes, "Ed25519", false, ["verify"]);
-		return cachedKey;
+	function getKey(): Promise<CryptoKey> {
+		if (!keyPromise) {
+			keyPromise = crypto.subtle.importKey("raw", keyBytes, "Ed25519", false, ["verify"]);
+		}
+		return keyPromise;
 	}
 
 	return {

--- a/tests/providers/discord.test.ts
+++ b/tests/providers/discord.test.ts
@@ -128,7 +128,7 @@ describe("discord provider", () => {
 				"X-Signature-Timestamp": TIMESTAMP,
 			}),
 		});
-		// Second call hits the cachedKey branch
+		// Second call reuses the cached key promise
 		const sig2 = await generateDiscordSignature("second", "2000000000", PRIVATE_KEY);
 		const result = await provider.verify({
 			rawBody: "second",


### PR DESCRIPTION
## Summary
- Cache the `Promise<CryptoKey>` instead of the resolved `CryptoKey` to prevent redundant `crypto.subtle.importKey()` calls under concurrent requests
- Update stale test comment to match new variable name

## Details

The previous pattern cached the resolved `CryptoKey` value:
```ts
let cachedKey: CryptoKey | null = null;
async function getKey(): Promise<CryptoKey> {
    if (cachedKey) return cachedKey;
    cachedKey = await crypto.subtle.importKey(...);
    return cachedKey;
}
```

Under concurrency, multiple callers could see `cachedKey === null` before any resolved, causing redundant `importKey` calls (TOCTOU).

The fix caches the Promise itself, which is assigned synchronously:
```ts
let keyPromise: Promise<CryptoKey> | null = null;
function getKey(): Promise<CryptoKey> {
    if (!keyPromise) {
        keyPromise = crypto.subtle.importKey(...);
    }
    return keyPromise;
}
```

## Test plan
- [x] All 159 existing tests pass
- [x] Discord-specific tests (11 tests) pass
- [x] Code review confirmed correctness
- [x] Security review passed — no vulnerabilities introduced

Closes #58

🤖 Generated with [Claude Code](https://claude.com/claude-code)