### PR TITLE
Validate Discord Ed25519 public key length at construction time

### DIFF
--- a/src/providers/discord.ts
+++ b/src/providers/discord.ts
@@ -14,6 +14,9 @@ export function discord(options: DiscordOptions): WebhookProvider {
 	if (!rawKey) {
 		throw new Error("discord: publicKey must be a valid hex string");
 	}
+	if (rawKey.byteLength !== 32) {
+		throw new Error("discord: publicKey must be 32 bytes (64 hex characters)");
+	}
 	// Store in a typed variable so TypeScript narrows across the closure.
 	const keyBytes: ArrayBuffer = rawKey;
 

--- a/tests/providers/discord.test.ts
+++ b/tests/providers/discord.test.ts
@@ -146,6 +146,13 @@ describe("discord provider", () => {
 		);
 	});
 
+	it("throws on wrong-length publicKey", () => {
+		// 16 bytes (32 hex chars) instead of required 32 bytes (64 hex chars)
+		expect(() => discord({ publicKey: "ab".repeat(16) })).toThrow(
+			"publicKey must be 32 bytes (64 hex characters)",
+		);
+	});
+
 	it("returns invalid-signature when crypto.subtle.verify throws", async () => {
 		const provider = discord({ publicKey: PUBLIC_KEY });
 		const signature = await generateDiscordSignature(BODY, TIMESTAMP, PRIVATE_KEY);


### PR DESCRIPTION
## Summary
- Add 32-byte length check for Ed25519 public key at `discord()` factory call time
- Surface misconfiguration errors at startup instead of deferring to first `verify()` call

## Test plan
- [x] All 160 tests pass (1 new test added)
- [x] New test verifies that a wrong-length key throws with descriptive message

Closes #60

🤖 Generated with [Claude Code](https://claude.com/claude-code)