### PR TITLE
Optimize toHex with pre-computed lookup table

### DIFF
--- a/src/crypto.ts
+++ b/src/crypto.ts
@@ -17,11 +17,16 @@ export async function hmac(
 	return crypto.subtle.sign("HMAC", key, encoder.encode(data));
 }
 
+const HEX_TABLE = Array.from({ length: 256 }, (_, i) => i.toString(16).padStart(2, "0"));
+
 /** Convert ArrayBuffer to hex string */
 export function toHex(buffer: ArrayBuffer): string {
-	return Array.from(new Uint8Array(buffer))
-		.map((b) => b.toString(16).padStart(2, "0"))
-		.join("");
+	const bytes = new Uint8Array(buffer);
+	let hex = "";
+	for (let i = 0; i < bytes.length; i++) {
+		hex += HEX_TABLE[bytes[i]];
+	}
+	return hex;
 }
 
 /** Decode a lowercase hex string into an ArrayBuffer. Returns null for invalid input. */


### PR DESCRIPTION
## Summary
- Replace `Array.from().map().join()` with a pre-computed 256-entry hex lookup table
- Eliminates intermediate array allocations on every `toHex()` call

## Before
```ts
export function toHex(buffer: ArrayBuffer): string {
    return Array.from(new Uint8Array(buffer))
        .map((b) => b.toString(16).padStart(2, "0"))
        .join("");
}
```

## After
```ts
const HEX_TABLE = Array.from({ length: 256 }, (_, i) => i.toString(16).padStart(2, "0"));

export function toHex(buffer: ArrayBuffer): string {
    const bytes = new Uint8Array(buffer);
    let hex = "";
    for (let i = 0; i < bytes.length; i++) {
        hex += HEX_TABLE[bytes[i]];
    }
    return hex;
}
```

## Test plan
- [x] All 160 existing tests pass
- [x] Crypto tests verify hex output against known values

Closes #62

🤖 Generated with [Claude Code](https://claude.com/claude-code)