### PR TITLE
Update release workflow to Node.js 22 (LTS)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: pnpm
           registry-url: "https://registry.npmjs.org"
 


### PR DESCRIPTION
## Summary
- Update release workflow from Node.js 20 to Node.js 22 (current LTS)
- Aligns release environment with CI matrix (which tests 20/22/24)

## Test plan
- [x] CI passes on all Node versions
- [x] No functional change to the package

Closes #64

🤖 Generated with [Claude Code](https://claude.com/claude-code)