### PR TITLE
Export error constructors for consistent custom error handling

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,12 @@ export type { DefineProviderInput } from "./define-provider.js";
 export { detectProvider } from "./detect.js";
 export type { ProviderName } from "./detect.js";
 export { hmac, toHex, fromHex, toBase64, fromBase64, timingSafeEqual } from "./crypto.js";
+export {
+	missingSignature,
+	invalidSignature,
+	timestampExpired,
+	bodyReadFailed,
+} from "./errors.js";
 export type {
 	WebhookVerifyOptions,
 	WebhookVerifyError,


### PR DESCRIPTION
## Summary
- Re-export `missingSignature`, `invalidSignature`, `timestampExpired`, and `bodyReadFailed` from the main entry point
- Enables users to construct RFC 9457 error responses in custom `onError` callbacks

## Test plan
- [x] All 160 tests pass
- [x] Build succeeds

Closes #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)