### PR TITLE
Add changeset for v0.2.0 release

### DIFF
--- a/.changeset/export-crypto-and-errors.md
+++ b/.changeset/export-crypto-and-errors.md
@@ -1,0 +1,16 @@
+---
+"hono-webhook-verify": minor
+---
+
+Export crypto utilities and error constructors, fix Discord provider race condition
+
+### New Features
+- Export crypto utilities (`hmac`, `toHex`, `fromHex`, `toBase64`, `fromBase64`, `timingSafeEqual`) for custom provider implementations
+- Export error constructors (`missingSignature`, `invalidSignature`, `timestampExpired`, `bodyReadFailed`) for consistent custom error handling
+
+### Bug Fixes
+- Fix Discord provider `cachedKey` race condition under concurrent requests (cache Promise instead of resolved value)
+- Validate Discord Ed25519 public key length (32 bytes) at construction time
+
+### Performance
+- Optimize `toHex` with pre-computed 256-entry lookup table


### PR DESCRIPTION
## Summary
- Add changeset for minor version bump (v0.2.0)
- Includes all changes since v0.1.1: new public API exports, Discord fixes, performance improvements

### Changes in v0.2.0
- **New**: Export crypto utilities (`hmac`, `toHex`, `fromHex`, `toBase64`, `fromBase64`, `timingSafeEqual`)
- **New**: Export error constructors (`missingSignature`, `invalidSignature`, `timestampExpired`, `bodyReadFailed`)
- **Fix**: Discord `cachedKey` race condition under concurrency
- **Fix**: Discord Ed25519 public key length validation at construction time
- **Perf**: `toHex` lookup table optimization

## Test plan
- [x] All 160 tests pass
- [x] Changeset file validates

Closes #72

🤖 Generated with [Claude Code](https://claude.com/claude-code)