### PR TITLE
feat: migrate error responses to use hono-problem-details

### DIFF
--- a/.changeset/use-hono-problem-details.md
+++ b/.changeset/use-hono-problem-details.md
@@ -2,8 +2,11 @@
 "hono-webhook-verify": minor
 ---
 
-Add hono-problem-details as optional peerDependency and fix Content-Type
+Add hono-problem-details as optional peerDependency with runtime fallback
 
-- Declare `hono-problem-details` as optional peerDependency for ecosystem compatibility
+- Declare `hono-problem-details` as optional peerDependency
+- When installed: error responses use `problemDetails().getResponse()` from hono-problem-details
+- When not installed: falls back to self-contained `new Response` implementation
 - Fix Content-Type: default error responses now return `application/problem+json` (was `application/json`)
+- Detection is lazy (first error path only) — no overhead on happy path
 - `onError` callback signature unchanged (backward-compatible)

--- a/package.json
+++ b/package.json
@@ -161,6 +161,7 @@
 		"@changesets/cli": "2.29.8",
 		"@vitest/coverage-v8": "^3.0.0",
 		"hono": "^4.7.0",
+		"hono-problem-details": "^0.1.0",
 		"lefthook": "2.1.1",
 		"tsup": "^8.0.0",
 		"typescript": "^5.7.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,10 +7,6 @@ settings:
 importers:
 
   .:
-    dependencies:
-      hono-problem-details:
-        specifier: '>=0.1.0'
-        version: 0.1.1(hono@4.12.1)
     devDependencies:
       '@biomejs/biome':
         specifier: ^1.9.0
@@ -27,6 +23,9 @@ importers:
       hono:
         specifier: ^4.7.0
         version: 4.12.1
+      hono-problem-details:
+        specifier: ^0.1.0
+        version: 0.1.1(hono@4.12.1)
       lefthook:
         specifier: 2.1.1
         version: 2.1.1

--- a/src/compat.ts
+++ b/src/compat.ts
@@ -1,0 +1,14 @@
+type HonoProblemDetails = typeof import("hono-problem-details");
+
+let cached: HonoProblemDetails | null | undefined;
+
+export async function getHonoProblemDetails(): Promise<HonoProblemDetails | null> {
+	if (cached === undefined) {
+		try {
+			cached = await import("hono-problem-details");
+		} catch {
+			cached = null;
+		}
+	}
+	return cached;
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,8 +1,20 @@
 import { createMiddleware } from "hono/factory";
+import { getHonoProblemDetails } from "./compat.js";
 import { bodyReadFailed, invalidSignature, missingSignature, timestampExpired } from "./errors.js";
 import type { WebhookVerifyError, WebhookVerifyOptions, WebhookVerifyVariables } from "./types.js";
 
-function errorResponse(error: WebhookVerifyError): Response {
+async function errorResponse(error: WebhookVerifyError): Promise<Response> {
+	const pd = await getHonoProblemDetails();
+	if (pd) {
+		return pd
+			.problemDetails({
+				type: error.type,
+				title: error.title,
+				status: error.status,
+				detail: error.detail,
+			})
+			.getResponse();
+	}
 	return new Response(JSON.stringify(error), {
 		status: error.status,
 		headers: { "Content-Type": "application/problem+json" },

--- a/tests/compat.test.ts
+++ b/tests/compat.test.ts
@@ -1,0 +1,73 @@
+import { Hono } from "hono";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { WebhookProvider } from "../src/types.js";
+
+const rejectingProvider: WebhookProvider = {
+	name: "test-reject",
+	verify: async () => ({ valid: false, reason: "invalid-signature" }),
+};
+
+describe("getHonoProblemDetails", () => {
+	beforeEach(() => {
+		vi.resetModules();
+	});
+
+	it("returns module when hono-problem-details is available", async () => {
+		const { getHonoProblemDetails } = await import("../src/compat.js");
+		const pd = await getHonoProblemDetails();
+		expect(pd).not.toBeNull();
+		expect(pd).toHaveProperty("problemDetails");
+	});
+
+	it("caches result on subsequent calls", async () => {
+		const { getHonoProblemDetails } = await import("../src/compat.js");
+		const first = await getHonoProblemDetails();
+		const second = await getHonoProblemDetails();
+		expect(first).toBe(second);
+	});
+
+	it("returns null when hono-problem-details is not installed", async () => {
+		vi.doMock("hono-problem-details", () => {
+			throw new Error("Cannot find module 'hono-problem-details'");
+		});
+		const { getHonoProblemDetails } = await import("../src/compat.js");
+		const pd = await getHonoProblemDetails();
+		expect(pd).toBeNull();
+	});
+
+	it("caches null when module is not available", async () => {
+		vi.doMock("hono-problem-details", () => {
+			throw new Error("Cannot find module 'hono-problem-details'");
+		});
+		const { getHonoProblemDetails } = await import("../src/compat.js");
+		await getHonoProblemDetails();
+		const second = await getHonoProblemDetails();
+		expect(second).toBeNull();
+	});
+});
+
+describe("middleware fallback when hono-problem-details is unavailable", () => {
+	beforeEach(() => {
+		vi.resetModules();
+	});
+
+	it("uses fallback response with application/problem+json", async () => {
+		vi.doMock("hono-problem-details", () => {
+			throw new Error("Cannot find module 'hono-problem-details'");
+		});
+		const { webhookVerify } = await import("../src/middleware.js");
+		const app = new Hono();
+		app.post("/webhook", webhookVerify({ provider: rejectingProvider }), (c) =>
+			c.json({ ok: true }),
+		);
+
+		const res = await app.request("/webhook", {
+			method: "POST",
+			body: "{}",
+		});
+		expect(res.status).toBe(401);
+		const body = await res.json();
+		expect(body.title).toBe("Webhook signature verification failed");
+		expect(res.headers.get("Content-Type")).toContain("application/problem+json");
+	});
+});

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -16,5 +16,5 @@ export default defineConfig({
 	dts: true,
 	clean: true,
 	sourcemap: true,
-	external: ["hono"],
+	external: ["hono", "hono-problem-details"],
 });


### PR DESCRIPTION
## Summary

- Add `hono-problem-details` as **optional** peerDependency
- Fix Content-Type: default error responses now return `application/problem+json` (was `application/json` via `c.json()`)
- Extract `errorResponse()` helper using `new Response` with correct Content-Type
- `onError` callback signature unchanged (backward-compatible)

## Not a breaking change (dependency)

`hono-problem-details` is optional via `peerDependenciesMeta`. Existing users are unaffected.

## Behavior change (Content-Type)

Default error responses now set `Content-Type: application/problem+json` instead of `application/json; charset=UTF-8`. This aligns with RFC 9457.

## Test plan

- [x] All 160 existing tests pass
- [x] Typecheck passes
- [x] Lint passes

Closes #75

🤖 Generated with [Claude Code](https://claude.com/claude-code)