### PR TITLE
perf: single-pass fromHex with nibble lookup table

### DIFF
--- a/benchmarks/crypto.bench.ts
+++ b/benchmarks/crypto.bench.ts
@@ -1,0 +1,38 @@
+import { bench, describe } from "vitest";
+import { fromBase64, fromHex, toBase64, toHex } from "../src/crypto.js";
+
+const shortHex = "8b5f48702995c1598c573db1e21866a9b825d4a794d169d7060a03605796360b";
+const shortBuffer = new Uint8Array(32).buffer;
+const shortBase64 = toBase64(shortBuffer);
+
+describe("fromHex", () => {
+	bench("decode SHA-256 hex (64 chars)", () => {
+		fromHex(shortHex);
+	});
+
+	bench("reject invalid hex", () => {
+		fromHex("zzzz");
+	});
+
+	bench("reject odd-length hex", () => {
+		fromHex("abc");
+	});
+});
+
+describe("toHex", () => {
+	bench("encode 32 bytes", () => {
+		toHex(shortBuffer);
+	});
+});
+
+describe("fromBase64", () => {
+	bench("decode 32 bytes base64", () => {
+		fromBase64(shortBase64);
+	});
+});
+
+describe("toBase64", () => {
+	bench("encode 32 bytes", () => {
+		toBase64(shortBuffer);
+	});
+});

--- a/src/crypto.ts
+++ b/src/crypto.ts
@@ -29,14 +29,24 @@ export function toHex(buffer: ArrayBuffer): string {
 	return hex;
 }
 
-/** Decode a lowercase hex string into an ArrayBuffer. Returns null for invalid input. */
+// charCode → nibble value; -1 for invalid characters
+const HEX_NIBBLE = new Int8Array(128).fill(-1);
+for (let i = 0; i < 10; i++) HEX_NIBBLE[0x30 + i] = i; // '0'-'9'
+for (let i = 0; i < 6; i++) {
+	HEX_NIBBLE[0x41 + i] = 10 + i; // 'A'-'F'
+	HEX_NIBBLE[0x61 + i] = 10 + i; // 'a'-'f'
+}
+
+/** Decode a hex string into an ArrayBuffer. Returns null for invalid input. */
 export function fromHex(hex: string): ArrayBuffer | null {
-	if (hex.length % 2 !== 0 || !/^[0-9a-f]*$/i.test(hex)) {
-		return null;
-	}
-	const bytes = new Uint8Array(hex.length / 2);
-	for (let i = 0; i < bytes.length; i++) {
-		bytes[i] = Number.parseInt(hex.slice(i * 2, i * 2 + 2), 16);
+	const len = hex.length;
+	if (len % 2 !== 0) return null;
+	const bytes = new Uint8Array(len >>> 1);
+	for (let i = 0; i < len; i += 2) {
+		const hi = HEX_NIBBLE[hex.charCodeAt(i)];
+		const lo = HEX_NIBBLE[hex.charCodeAt(i + 1)];
+		if (hi === -1 || lo === -1) return null;
+		bytes[i >>> 1] = (hi << 4) | lo;
 	}
 	return bytes.buffer;
 }


### PR DESCRIPTION
## Summary
- Replace regex validation + `Number.parseInt` loop with a single-pass nibble lookup table
- Pre-compute `HEX_NIBBLE` array (charCode → nibble value) at module init
- Validation and conversion now happen in one pass

Closes #81

## Benchmark Results

### fromHex

| Scenario | Before | After | Speedup |
|----------|--------|-------|---------|
| Decode SHA-256 hex (64 chars) | 957,875 ops/s | 6,456,207 ops/s | **6.74x** |
| Reject invalid hex | 31,073,131 ops/s | 22,748,125 ops/s | 0.73x* |
| Reject odd-length hex | 41,214,537 ops/s | 41,928,290 ops/s | ~same |

\* The reject-invalid path is slightly slower because validation now happens inline during the loop instead of a one-shot regex. This doesn't matter in practice — invalid inputs are rare and still extremely fast (22M ops/s).

### Other functions (unchanged, for reference)
| Function | ops/s |
|----------|-------|
| toHex (32 bytes) | 6,299,592 |
| fromBase64 (32 bytes) | 4,710,896 |
| toBase64 (32 bytes) | 2,918,843 |

## Test plan
- [x] All 165 tests pass
- [x] 100% coverage maintained
- [x] Lint + typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)