### PR TITLE
fix: reject non-ASCII chars in fromHex

### DIFF
--- a/src/crypto.ts
+++ b/src/crypto.ts
@@ -43,8 +43,11 @@ export function fromHex(hex: string): ArrayBuffer | null {
 	if (len % 2 !== 0) return null;
 	const bytes = new Uint8Array(len >>> 1);
 	for (let i = 0; i < len; i += 2) {
-		const hi = HEX_NIBBLE[hex.charCodeAt(i)];
-		const lo = HEX_NIBBLE[hex.charCodeAt(i + 1)];
+		const c1 = hex.charCodeAt(i);
+		const c2 = hex.charCodeAt(i + 1);
+		if (c1 >= 128 || c2 >= 128) return null;
+		const hi = HEX_NIBBLE[c1];
+		const lo = HEX_NIBBLE[c2];
 		if (hi === -1 || lo === -1) return null;
 		bytes[i >>> 1] = (hi << 4) | lo;
 	}

--- a/tests/crypto.test.ts
+++ b/tests/crypto.test.ts
@@ -56,6 +56,12 @@ describe("fromHex", () => {
 		expect(fromHex("zz")).toBeNull();
 	});
 
+	it("returns null for non-ASCII characters (charCode >= 128)", () => {
+		expect(fromHex("café")).toBeNull();
+		expect(fromHex("ff\u0080ff")).toBeNull();
+		expect(fromHex("\u00e9\u00e9")).toBeNull();
+	});
+
 	it("handles empty string", () => {
 		const buf = fromHex("") as ArrayBuffer;
 		expect(buf.byteLength).toBe(0);


### PR DESCRIPTION
## Summary
- `HEX_NIBBLE` is `Int8Array(128)` — charCodes >= 128 return `undefined` not `-1`, bypassing the validation guard
- Silent zero-byte corruption: `(undefined << 4) | undefined` evaluates to `0`
- Add bounds check before array access to reject non-ASCII input

## Changes
- `src/crypto.ts`: Add `c1 >= 128 || c2 >= 128` guard before `HEX_NIBBLE` lookup
- `tests/crypto.test.ts`: Add test for non-ASCII characters (`café`, `\u0080`, `\u00e9`)

Closes #83

## Test plan
- [x] New test verifies non-ASCII input returns `null`
- [x] All existing tests pass (166/166)
- [x] Lint + typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)