### PR TITLE
chore: add changeset for release + update hono-problem-details to 0.1.2

### DIFF
--- a/.changeset/security-hardening.md
+++ b/.changeset/security-hardening.md
@@ -1,0 +1,5 @@
+---
+"hono-webhook-verify": patch
+---
+
+Security hardening: fix fromHex non-ASCII bounds check, require Slack v0= prefix, limit Standard Webhooks signature count, add Discord timestamp tolerance

--- a/package.json
+++ b/package.json
@@ -161,7 +161,7 @@
 		"@changesets/cli": "2.29.8",
 		"@vitest/coverage-v8": "^3.0.0",
 		"hono": "^4.7.0",
-		"hono-problem-details": "^0.1.0",
+		"hono-problem-details": "0.1.2",
 		"lefthook": "2.1.1",
 		"tsup": "^8.0.0",
 		"typescript": "^5.7.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,8 +24,8 @@ importers:
         specifier: ^4.7.0
         version: 4.12.1
       hono-problem-details:
-        specifier: ^0.1.0
-        version: 0.1.1(hono@4.12.1)
+        specifier: 0.1.2
+        version: 0.1.2(hono@4.12.1)
       lefthook:
         specifier: 2.1.1
         version: 2.1.1
@@ -807,8 +807,8 @@ packages:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
 
-  hono-problem-details@0.1.1:
-    resolution: {integrity: sha512-cGeoDvGjxLGrG1E095T5fcsFVghYfuOsPinIb3p2QlfYNuZ+w4zWzJcNgM7BoVgEhPCbmYXVXBEZ4cPD34yXPg==}
+  hono-problem-details@0.1.2:
+    resolution: {integrity: sha512-Rbr6/uWU8WhSzXrjO7LugpUCLEqxCAiPS5kEJQRY91Z/Vt6lLhN6QLvotkewJUq9ipiSk3YZ7eGzwFTeJA2rlw==}
     engines: {node: '>=20'}
     peerDependencies:
       '@hono/standard-validator': '*'
@@ -2183,7 +2183,7 @@ snapshots:
 
   has-flag@4.0.0: {}
 
-  hono-problem-details@0.1.1(hono@4.12.1):
+  hono-problem-details@0.1.2(hono@4.12.1):
     dependencies:
       hono: 4.12.1
 


### PR DESCRIPTION
## Summary
- Add changeset for v0.3.1 release (security hardening patch)
- Update `hono-problem-details` devDependency from ^0.1.0 to 0.1.2

## Test plan
- [x] Existing tests pass
- [x] Dependency version updated correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)