### PR TITLE
fix: type-safe error mapping, await errorResponse, Slack edge case test

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -19,5 +19,6 @@ export type {
 	WebhookProvider,
 	ProviderFactory,
 	VerifyContext,
+	VerifyFailureReason,
 	VerifyResult,
 } from "./providers/types.js";

--- a/src/providers/types.ts
+++ b/src/providers/types.ts
@@ -1,7 +1,10 @@
+/** Known verification failure reasons */
+export type VerifyFailureReason = "missing-signature" | "invalid-signature" | "timestamp-expired";
+
 /** Provider verification result */
 export interface VerifyResult {
 	valid: boolean;
-	reason?: string;
+	reason?: VerifyFailureReason;
 }
 
 /** Context passed to provider's verify method */

--- a/tests/providers/slack.test.ts
+++ b/tests/providers/slack.test.ts
@@ -207,4 +207,17 @@ describe("slack provider", () => {
 		});
 		expect(result).toEqual({ valid: false, reason: "invalid-signature" });
 	});
+
+	it("rejects v0= prefix with empty hex", async () => {
+		const provider = slack({ signingSecret: SECRET });
+		const timestamp = Math.floor(Date.now() / 1000);
+		const result = await provider.verify({
+			rawBody: BODY,
+			headers: new Headers({
+				"X-Slack-Signature": "v0=",
+				"X-Slack-Request-Timestamp": String(timestamp),
+			}),
+		});
+		expect(result).toEqual({ valid: false, reason: "invalid-signature" });
+	});
 });


### PR DESCRIPTION
## Summary
- Add `VerifyFailureReason` type union (`"missing-signature" | "invalid-signature" | "timestamp-expired"`)
- Use typed `Record<VerifyFailureReason, ...>` for error mapping with fallback for custom providers
- Add `await` to all `errorResponse()` calls for consistency
- Add Slack `v0=` empty hex edge case test
- Export `VerifyFailureReason` from main index

Closes #90

## Test plan
- [x] Added Slack `v0=` empty hex test
- [x] Existing test M13 (custom reason fallback) still passes
- [x] All 173 tests pass
- [x] Lint and typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced type safety for verification failures with explicit reason categorization.
  * Improved error handling with fallback mechanisms for edge cases.

* **Tests**
  * Added coverage for signature validation edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->