### PR TITLE
chore: add changeset for security patch release

### DIFF
--- a/.changeset/security-dev-deps-refresh.md
+++ b/.changeset/security-dev-deps-refresh.md
@@ -1,0 +1,5 @@
+---
+"hono-webhook-verify": patch
+---
+
+Refresh dev dependency lockfile to resolve Dependabot security alerts in `vite`, `picomatch`, and `minimatch`. No runtime or API changes — all affected packages are transitive dev dependencies.


### PR DESCRIPTION
## Summary
- Adds a changeset to trigger a patch release documenting the security lockfile refresh from #106
- Resolved 6 Dependabot alerts: `vite` (3), `picomatch` (2), `minimatch` (1) — all transitive dev dependencies
- Published tarball contents (`dist/*`) are unchanged; this release is for security posture visibility

## Follow-up flow
Once merged, the `changesets/action` workflow will open a "Version Packages" PR bumping `0.3.5` → `0.3.6`. Merging that triggers the npm publish.

## Test plan
- [x] Changeset file validates (single entry, correct frontmatter)
- [ ] Version Packages PR opens after merge
- [ ] Release publishes `0.3.6` to npm

🤖 Generated with [Claude Code](https://claude.com/claude-code)