### PR TITLE
docs: document error helper functions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,6 +247,29 @@ webhookVerify({
 });
 ```
 
+### Error Helpers
+
+When wrapping the middleware or building a higher-level handler, use these helpers to construct `WebhookVerifyError` objects matching the same Problem Details format:
+
+```ts
+import { invalidSignature } from "hono-webhook-verify";
+
+const error = invalidSignature("HMAC mismatch");
+// => {
+//   type: "https://hono-webhook-verify.dev/errors/invalid-signature",
+//   title: "Webhook signature verification failed",
+//   status: 401,
+//   detail: "HMAC mismatch",
+// }
+```
+
+| Helper | Status | Use when |
+|--------|--------|----------|
+| `missingSignature(detail)` | 401 | Required signature header is absent |
+| `invalidSignature(detail)` | 401 | HMAC / Ed25519 verification fails |
+| `timestampExpired(detail)` | 401 | Replay window exceeded |
+| `bodyReadFailed(detail)` | 400 | Request body could not be read |
+
 ## Provider Auto-Detection
 
 Use `detectProvider()` to identify the webhook source from request headers:


### PR DESCRIPTION
## Summary
- Document the four `WebhookVerifyError` constructor helpers (`missingSignature`, `invalidSignature`, `timestampExpired`, `bodyReadFailed`) that are exported from `src/index.ts` but were missing from the README
- Adds an "Error Helpers" subsection at the end of "Error Handling" with one example and a 4-row reference table

## Why
These helpers are public API at the same export level as the crypto helpers (`hmac`, `toHex`, etc.), but only the crypto side was documented — leaving an inconsistency. Users wrapping the middleware or building a higher-level handler had no way to discover them from the README.

Found during a doc-drift check after the recent llms.txt and funding-field merges.

## Scope
- Documentation only — no source changes
- No new exports, no API changes

## Test plan
- [ ] Rendered table displays correctly on GitHub
- [ ] Example output matches `src/errors.ts` exactly (verified locally: same `type`, `title`, `status`, `detail` shape)
- [ ] `Error Handling` section flow still reads naturally with the new subsection inserted

🤖 Generated with [Claude Code](https://claude.com/claude-code)
