### PR TITLE
chore: add changeset for docs and funding patch release

### DIFF
--- a/.changeset/docs-error-helpers-and-funding.md
+++ b/.changeset/docs-error-helpers-and-funding.md
@@ -1,0 +1,10 @@
+---
+"hono-webhook-verify": patch
+---
+
+Documentation and metadata refresh:
+
+- Document the `WebhookVerifyError` constructor helpers (`missingSignature`, `invalidSignature`, `timestampExpired`, `bodyReadFailed`) in the README's Error Handling section. These are public exports for users wrapping the middleware or building higher-level handlers.
+- Add a `funding` field to `package.json` so npm and GitHub display the project's sponsor link.
+
+No runtime or API changes — all exports and behavior are unchanged.


### PR DESCRIPTION
## Summary
Add a `patch` changeset covering two recently merged docs/metadata changes that are visible to npm consumers but had no associated changeset:

- README "Error Helpers" subsection (#111) — exposes the four `WebhookVerifyError` constructor helpers in user-facing docs
- `funding` field in `package.json` (#109) — refreshes npm/GitHub sponsor link metadata

## Why patch (not skipped)
`files: ["dist"]` does not exclude README or `package.json` — npm always publishes both. Until the next release, npmjs.com shows stale README and missing funding link. Bumping matches this repo's convention of cutting non-functional patch releases (e.g. #107 security dev-deps refresh).

llms.txt (#110) is intentionally **not** mentioned — it lives only in the repo, not in the published package.

## Effect after merge
1. `changesets/action` will automatically open a "Version Packages" PR bumping `0.3.6` → `0.3.7` and updating `CHANGELOG.md`.
2. Merging that PR triggers the existing release workflow to publish to npm.

## Test plan
- [ ] Changeset frontmatter matches the convention (`"hono-webhook-verify": patch`)
- [ ] CI passes on this PR
- [ ] After merge, `changesets/action` opens the Version Packages PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)
