### PR TITLE
fix(deps): bump postcss to 8.5.13 (CVE-2026-41305)

### DIFF
--- a/.changeset/security-postcss-xss.md
+++ b/.changeset/security-postcss-xss.md
@@ -1,0 +1,5 @@
+---
+"hono-webhook-verify": patch
+---
+
+Refresh `postcss` (transitive dev dependency via `tsup`) from 8.5.6 to 8.5.13 to resolve Dependabot alert GHSA-qx2v-qp2m-jg93 / CVE-2026-41305 (XSS via unescaped `</style>` in CSS stringify output). No runtime or API changes — `postcss` is only used at build time and is not part of the published package.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,7 +31,7 @@ importers:
         version: 2.1.1
       tsup:
         specifier: ^8.0.0
-        version: 8.5.1(postcss@8.5.6)(typescript@5.9.3)
+        version: 8.5.1(postcss@8.5.13)(typescript@5.9.3)
       typescript:
         specifier: ^5.7.0
         version: 5.9.3
@@ -1146,8 +1146,8 @@ packages:
       yaml:
         optional: true
 
-  postcss@8.5.6:
-    resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
+  postcss@8.5.13:
+    resolution: {integrity: sha512-qif0+jGGZoLWdHey3UFHHWP0H7Gbmsk8T5VEqyYFbWqPr1XqvLGBbk/sl8V5exGmcYJklJOhOQq1pV9IcsiFag==}
     engines: {node: ^10 || ^12 || >=14}
 
   prettier@2.8.8:
@@ -2427,13 +2427,13 @@ snapshots:
       mlly: 1.8.0
       pathe: 2.0.3
 
-  postcss-load-config@6.0.1(postcss@8.5.6):
+  postcss-load-config@6.0.1(postcss@8.5.13):
     dependencies:
       lilconfig: 3.1.3
     optionalDependencies:
-      postcss: 8.5.6
+      postcss: 8.5.13
 
-  postcss@8.5.6:
+  postcss@8.5.13:
     dependencies:
       nanoid: 3.3.11
       picocolors: 1.1.1
@@ -2605,7 +2605,7 @@ snapshots:
 
   ts-interface-checker@0.1.13: {}
 
-  tsup@8.5.1(postcss@8.5.6)(typescript@5.9.3):
+  tsup@8.5.1(postcss@8.5.13)(typescript@5.9.3):
     dependencies:
       bundle-require: 5.1.0(esbuild@0.27.3)
       cac: 6.7.14
@@ -2616,7 +2616,7 @@ snapshots:
       fix-dts-default-cjs-exports: 1.0.1
       joycon: 3.1.1
       picocolors: 1.1.1
-      postcss-load-config: 6.0.1(postcss@8.5.6)
+      postcss-load-config: 6.0.1(postcss@8.5.13)
       resolve-from: 5.0.0
       rollup: 4.59.0
       source-map: 0.7.6
@@ -2625,7 +2625,7 @@ snapshots:
       tinyglobby: 0.2.15
       tree-kill: 1.2.2
     optionalDependencies:
-      postcss: 8.5.6
+      postcss: 8.5.13
       typescript: 5.9.3
     transitivePeerDependencies:
       - jiti
@@ -2665,7 +2665,7 @@ snapshots:
       esbuild: 0.27.3
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
-      postcss: 8.5.6
+      postcss: 8.5.13
       rollup: 4.59.0
       tinyglobby: 0.2.15
     optionalDependencies:


### PR DESCRIPTION
## Summary
- Resolves Dependabot alert [#22](https://github.com/paveg/hono-webhook-verify/security/dependabot/22) (GHSA-qx2v-qp2m-jg93 / CVE-2026-41305 — XSS via unescaped `</style>` in PostCSS CSS stringify output, severity moderate / CVSS 6.1).
- `postcss` is a **transitive dev dependency** via `tsup`. `pnpm update postcss` re-resolved within the existing semver range (`^8.4.12`), bumping `8.5.6` → `8.5.13`. `package.json` is untouched.
- Patch changeset added per project convention for release-note visibility, even though the published package (`dist/*`) is unaffected.

## Test plan
- [x] `pnpm install --frozen-lockfile` — clean
- [x] `pnpm run build` — success
- [x] `pnpm test` — 193/193 passing
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated development dependencies to address a security vulnerability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->