### PR TITLE
chore: drop Node.js 20 support (EOL 2026-04-30)

### DIFF
--- a/.changeset/drop-node-20.md
+++ b/.changeset/drop-node-20.md
@@ -1,0 +1,7 @@
+---
+"hono-webhook-verify": minor
+---
+
+Drop Node.js 20 support (reached EOL on 2026-04-30). The minimum supported runtime is now Node.js 22. CI matrix updated to `[22, 24]`.
+
+If you still need Node.js 20, pin to `hono-webhook-verify@0.3.x`.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [20, 22, 24]
+        node-version: [22, 24]
     steps:
       - uses: actions/checkout@v4
 

--- a/package.json
+++ b/package.json
@@ -157,7 +157,7 @@
 		"provenance": true
 	},
 	"engines": {
-		"node": ">=20"
+		"node": ">=22"
 	},
 	"peerDependencies": {
 		"hono": ">=4.0.0",


### PR DESCRIPTION
## Summary

Node.js 20 reached EOL on **2026-04-30**. This PR raises the minimum supported runtime to Node.js 22 and removes Node 20 from CI.

- `package.json` — `engines.node`: `>=20` → `>=22`
- `.github/workflows/ci.yml` — matrix `[20, 22, 24]` → `[22, 24]`
- `.changeset/drop-node-20.md` — `minor` bump (signals breaking runtime requirement on a 0.x package)

Release workflow already pins to Node 24 (npm 11.x for OIDC Trusted Publishing) so it is unaffected.

## Why minor (not patch)

Raising `engines.node` is a breaking change for downstream consumers — users on Node 20 will see an `engines` warning (or error with `engine-strict=true`). On a 0.x package, `minor` is the conventional signal for breaking changes. Users who must stay on Node 20 can pin to `0.3.x`.

## Test plan

- [x] `pnpm install --frozen-lockfile` — clean
- [x] `pnpm typecheck` — clean
- [x] `pnpm test` — 193/193 passed across 15 files
- [x] `pnpm build` — clean
- [ ] CI matrix `[22, 24]` green
- [ ] Local Node 22 spot-check (CI handles this automatically)

## Follow-up (separate PR)

Mirror [paveg/hono-problem-details#121](https://github.com/paveg/hono-problem-details/pull/121) — add a TypeScript consumer-compat matrix (type-check `dist/`'s `.d.ts` against TS 5.0/5.4/5.7/5.9) to guard against future `.d.ts` syntax leaks breaking older TS consumers silently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
