### PR TITLE
ci: add TypeScript compat matrix (5.0/5.4/5.7/5.9)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,10 +32,36 @@ jobs:
 
       - run: pnpm build
 
+  type-compat:
+    runs-on: ubuntu-latest
+    needs: ci
+    strategy:
+      fail-fast: false
+      matrix:
+        ts: ["5.0.4", "5.4.5", "5.7.3", "5.9.3"]
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - run: pnpm build
+
+      - name: Type-check consumer against TS ${{ matrix.ts }}
+        env:
+          TS_VERSION: ${{ matrix.ts }}
+        run: pnpm dlx --package="typescript@${TS_VERSION}" -c 'tsc -p tsconfig.compat.json'
+
   ci-pass:
     if: always()
-    needs: ci
+    needs: [ci, type-compat]
     runs-on: ubuntu-latest
     steps:
       - run: exit 1
-        if: needs.ci.result != 'success'
+        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')

--- a/README.md
+++ b/README.md
@@ -24,6 +24,12 @@ Works on Cloudflare Workers, Deno, Bun, Node.js, and any platform that supports 
 | **Standard Webhooks** | `webhook-signature` | HMAC-SHA256 (svix-compatible) |
 | **Custom** | Any | `defineProvider()` |
 
+## Requirements
+
+- **Node.js**: `>= 22` (Node 20 reached EOL on 2026-04-30). Also runs on Cloudflare Workers, Deno, and Bun.
+- **TypeScript**: `>= 5.0` — verified in CI against TS 5.0 / 5.4 / 5.7 / 5.9 to guard the published `.d.ts` against silent breakage.
+- **Hono**: `>= 4.0`
+
 ## Installation
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -120,6 +120,7 @@
 		"lint:fix": "biome check --write .",
 		"format": "biome format --write .",
 		"typecheck": "tsc --noEmit",
+		"test:compat": "tsc -p tsconfig.compat.json",
 		"release": "pnpm build && changeset publish",
 		"version-packages": "changeset version && pnpm lint:fix"
 	},

--- a/tests/type-compat/core-consumer.ts
+++ b/tests/type-compat/core-consumer.ts
@@ -1,0 +1,118 @@
+import type {
+	DefineProviderInput,
+	ProviderFactory,
+	ProviderName,
+	VerifyContext,
+	VerifyFailureReason,
+	VerifyResult,
+	WebhookProvider,
+	WebhookVerifyError,
+	WebhookVerifyOptions,
+	WebhookVerifyVariables,
+} from "../../dist/index.js";
+import {
+	bodyReadFailed,
+	defineProvider,
+	detectProvider,
+	fromBase64,
+	fromHex,
+	hmac,
+	invalidSignature,
+	missingSignature,
+	timestampExpired,
+	timingSafeEqual,
+	toBase64,
+	toHex,
+	webhookVerify,
+} from "../../dist/index.js";
+
+const _failureReason: VerifyFailureReason = "missing-signature";
+const _result: VerifyResult = { valid: true };
+const _ctx: VerifyContext = { rawBody: "", headers: new Headers() };
+
+const _provider: WebhookProvider = {
+	name: "test",
+	async verify(_c) {
+		return { valid: true };
+	},
+};
+
+const _factory: ProviderFactory<{ secret: string }> = (opts) => ({
+	name: "custom",
+	async verify(_c) {
+		void opts.secret;
+		return { valid: true };
+	},
+});
+
+const _detectName: ProviderName | null = detectProvider(new Headers());
+
+const _err: WebhookVerifyError = {
+	type: "https://example.com/missing",
+	title: "Missing",
+	status: 401,
+	detail: "...",
+};
+
+const _opts: WebhookVerifyOptions = { provider: _provider };
+const _vars: WebhookVerifyVariables = {
+	webhookRawBody: "",
+	webhookPayload: null,
+	webhookProvider: "stripe",
+};
+
+const _middleware = webhookVerify({ provider: _provider });
+
+const _customFactory = defineProvider<{ secret: string }>((opts) => ({
+	name: "x",
+	async verify(_c) {
+		void opts.secret;
+		return { valid: true };
+	},
+}));
+const _custom = _customFactory({ secret: "abc" });
+
+const _input: DefineProviderInput = {
+	name: "x",
+	async verify(_c) {
+		return { valid: true };
+	},
+};
+
+const _e1 = missingSignature("X-Sig");
+const _e2 = invalidSignature("stripe");
+const _e3 = timestampExpired("300s exceeded");
+const _e4 = bodyReadFailed("read failure");
+
+async function _cryptoCheck() {
+	const sig = await hmac("SHA-256", "secret", "payload");
+	const hex = toHex(sig);
+	const back1 = fromHex(hex);
+	const b64 = toBase64(sig);
+	const back2 = fromBase64(b64);
+	const eq = timingSafeEqual(sig, sig);
+	void hex;
+	void back1;
+	void b64;
+	void back2;
+	void eq;
+}
+
+void _failureReason;
+void _result;
+void _ctx;
+void _provider;
+void _factory;
+void _detectName;
+void _err;
+void _opts;
+void _vars;
+void _middleware;
+void _customFactory;
+void _custom;
+void _input;
+void _e1;
+void _e2;
+void _e3;
+void _e4;
+void _cryptoCheck;

--- a/tests/type-compat/providers-consumer.ts
+++ b/tests/type-compat/providers-consumer.ts
@@ -1,0 +1,41 @@
+import { type DiscordOptions, discord } from "../../dist/providers/discord.js";
+import { type GitHubOptions, github } from "../../dist/providers/github.js";
+import { type LineOptions, line } from "../../dist/providers/line.js";
+import { type ShopifyOptions, shopify } from "../../dist/providers/shopify.js";
+import { type SlackOptions, slack } from "../../dist/providers/slack.js";
+import {
+	type StandardWebhooksOptions,
+	standardWebhooks,
+} from "../../dist/providers/standard-webhooks.js";
+import { type StripeOptions, stripe } from "../../dist/providers/stripe.js";
+import { type TwilioOptions, twilio } from "../../dist/providers/twilio.js";
+
+const _stripeOpts: StripeOptions = { secret: "whsec_x", tolerance: 300 };
+const _githubOpts: GitHubOptions = { secret: "ghs_x" };
+const _slackOpts: SlackOptions = { signingSecret: "shh", tolerance: 300 };
+const _shopifyOpts: ShopifyOptions = { secret: "shopify_x" };
+const _twilioOpts: TwilioOptions = { authToken: "tok_x" };
+const _lineOpts: LineOptions = { channelSecret: "line_x" };
+const _discordOpts: DiscordOptions = {
+	publicKey: "0".repeat(64),
+	tolerance: 300,
+};
+const _swOpts: StandardWebhooksOptions = { secret: "whsec_swh", tolerance: 300 };
+
+const _stripe = stripe(_stripeOpts);
+const _github = github(_githubOpts);
+const _slack = slack(_slackOpts);
+const _shopify = shopify(_shopifyOpts);
+const _twilio = twilio(_twilioOpts);
+const _line = line(_lineOpts);
+const _discord = discord(_discordOpts);
+const _sw = standardWebhooks(_swOpts);
+
+void _stripe;
+void _github;
+void _slack;
+void _shopify;
+void _twilio;
+void _line;
+void _discord;
+void _sw;

--- a/tsconfig.compat.json
+++ b/tsconfig.compat.json
@@ -1,0 +1,15 @@
+{
+	"compilerOptions": {
+		"target": "ES2022",
+		"module": "ESNext",
+		"moduleResolution": "bundler",
+		"lib": ["ES2022", "DOM"],
+		"strict": true,
+		"esModuleInterop": true,
+		"skipLibCheck": true,
+		"isolatedModules": true,
+		"noEmit": true,
+		"types": []
+	},
+	"include": ["tests/type-compat/**/*.ts"]
+}


### PR DESCRIPTION
## Summary

Mirrors [paveg/hono-problem-details#121](https://github.com/paveg/hono-problem-details/pull/121). Establishes the **TS 5.0+** floor as a CI-verified invariant rather than a docs-only claim.

### What this guards against

The library is built with a pinned dev TypeScript (`^5.7`), but consumers may compile against older TS. If a future build emits `.d.ts` syntax requiring a newer TS than declared, library users on the older TS would see compile errors with no warning at PR time. The matrix detects this at PR time.

### How it works

```mermaid
flowchart LR
  A[ci job<br/>node 22, 24<br/>builds dist/] --> B[type-compat matrix]
  B --> M1[TS 5.0.4<br/>tsc consumer]
  B --> M2[TS 5.4.5<br/>tsc consumer]
  B --> M3[TS 5.7.3<br/>tsc consumer]
  B --> M4[TS 5.9.3<br/>tsc consumer]
  M1 & M2 & M3 & M4 --> P[ci-pass]
```

- `tests/type-compat/core-consumer.ts` exercises the full main entry surface — `webhookVerify`, `defineProvider`, `detectProvider`, crypto helpers, errors, and every type export — importing from the post-build `dist/index.js`.
- `tests/type-compat/providers-consumer.ts` exercises each of the **8 provider subpath exports** (`stripe` / `github` / `slack` / `shopify` / `twilio` / `line` / `discord` / `standard-webhooks`).
- `tsconfig.compat.json` type-checks the consumer files in isolation with `ES2022 + bundler resolution + strict` (the typical consumer config). It is **not** part of the main `pnpm typecheck` (excluded via existing `tsconfig.json` rule).
- New CI job `type-compat` runs after `ci` (which builds `dist/`) and re-checks the consumer files against each matrix TS version via `pnpm dlx --package=typescript@${TS_VERSION}`.
- Matrix value is passed via `env: TS_VERSION` (defense-in-depth against workflow injection patterns, even though matrix values are controlled).
- `ci-pass` now requires **both** `ci` and `type-compat` to succeed.

### Why now

Companion to #117 (Node 20 EOL drop). Now that the runtime floor is locked, locking the consumer-side TS floor closes the other half of the supported-platform contract.

### Scope

Core API + all 8 provider subpaths. No CI infra hardening (SHA-pinned actions / pnpm store cache as in the sister repo) — that is a separate concern and would inflate this PR beyond its single purpose.

## Test plan

- [x] `pnpm build` — clean
- [x] `pnpm test:compat` — clean with current TS (5.7+)
- [x] `pnpm dlx --package=typescript@5.0.4 -c 'tsc -p tsconfig.compat.json'` — clean
- [x] `pnpm dlx --package=typescript@5.4.5 -c 'tsc -p tsconfig.compat.json'` — clean
- [x] `pnpm dlx --package=typescript@5.9.3 -c 'tsc -p tsconfig.compat.json'` — clean
- [x] `pnpm typecheck` / `pnpm test` — green (193/193, no regression)
- [x] CI workflow uses `env:` for matrix values (workflow-injection defense-in-depth)
- [ ] CI matrix `[5.0.4, 5.4.5, 5.7.3, 5.9.3]` × type-compat green

## Follow-up (separate PR)

Adopt the sister repo's CI hardening — SHA-pinned action versions, corepack invocation, and pnpm store cache — to reduce supply-chain surface and speed up CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
