### PR TITLE
chore(deps): migrate to TypeScript 6.0.3 (Phase 2: ignoreDeprecations + matrix)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ts: ["5.0.4", "5.4.5", "5.7.3", "5.9.3"]
+        ts: ["5.0.4", "5.4.5", "5.7.3", "5.9.3", "6.0.3"]
     steps:
       - uses: actions/checkout@v4
 

--- a/package.json
+++ b/package.json
@@ -178,7 +178,7 @@
 		"hono-problem-details": "0.1.4",
 		"lefthook": "2.1.1",
 		"tsup": "^8.0.0",
-		"typescript": "^5.7.0",
+		"typescript": "^6.0.3",
 		"vitest": "^3.0.0"
 	},
 	"packageManager": "pnpm@10.14.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,10 +31,10 @@ importers:
         version: 2.1.1
       tsup:
         specifier: ^8.0.0
-        version: 8.5.1(postcss@8.5.13)(typescript@5.9.3)
+        version: 8.5.1(postcss@8.5.13)(typescript@6.0.3)
       typescript:
-        specifier: ^5.7.0
-        version: 5.9.3
+        specifier: ^6.0.3
+        version: 6.0.3
       vitest:
         specifier: ^3.0.0
         version: 3.2.4
@@ -1334,8 +1334,8 @@ packages:
       typescript:
         optional: true
 
-  typescript@5.9.3:
-    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+  typescript@6.0.3:
+    resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -2605,7 +2605,7 @@ snapshots:
 
   ts-interface-checker@0.1.13: {}
 
-  tsup@8.5.1(postcss@8.5.13)(typescript@5.9.3):
+  tsup@8.5.1(postcss@8.5.13)(typescript@6.0.3):
     dependencies:
       bundle-require: 5.1.0(esbuild@0.27.3)
       cac: 6.7.14
@@ -2626,14 +2626,14 @@ snapshots:
       tree-kill: 1.2.2
     optionalDependencies:
       postcss: 8.5.13
-      typescript: 5.9.3
+      typescript: 6.0.3
     transitivePeerDependencies:
       - jiti
       - supports-color
       - tsx
       - yaml
 
-  typescript@5.9.3: {}
+  typescript@6.0.3: {}
 
   ufo@1.6.3: {}
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,8 @@
 		"sourceMap": true,
 		"outDir": "./dist",
 		"rootDir": "./src",
-		"types": []
+		"types": [],
+		"ignoreDeprecations": "6.0"
 	},
 	"include": ["src"],
 	"exclude": ["node_modules", "dist", "tests"]


### PR DESCRIPTION
## Summary

Phase 2 of the TypeScript-version contract: bumps the project's own TypeScript from `^5.7.0` to `^6.0.3` and locks the consumer-side compat matrix to include `6.0.3`. Builds on the `type-compat` matrix added in #119, which made this bump verifiable rather than a leap of faith.

Mirrors [paveg/hono-cf-access#45](https://github.com/paveg/hono-cf-access/pull/45).

## Why a plain bump alone fails

`tsup@8.5.1`'s DTS bundler hard-codes `baseUrl: "."` into the TS compiler options it constructs. TypeScript 6.0 deprecates `baseUrl` and emits:

```
error TS5101: Option 'baseUrl' is deprecated and will stop functioning in TypeScript 7.0.
  Specify compilerOption '"ignoreDeprecations": "6.0"' to silence this error.
```

The project `tsconfig.json` has no `baseUrl` of its own — the deprecation comes entirely from tsup's runtime injection ([tsup#1388](https://github.com/egoist/tsup/issues/1388)). The error message names the only sanctioned remediation: set `ignoreDeprecations: "6.0"` on the project tsconfig and let it propagate into tsup's DTS step.

## What this PR changes

| Change | File | Why |
|---|---|---|
| `typescript: ^5.7.0` → `^6.0.3` | `package.json` | The actual TS major bump. |
| Add `"ignoreDeprecations": "6.0"` | `tsconfig.json` | TS-official escape hatch for deprecated options; valid for the TS6 series, removed in TS7. Lets tsup's DTS step finish without TS5101. |
| Append `6.0.3` to `ts:` matrix | `.github/workflows/ci.yml` | Extends the consumer compat contract to the current TS major (was 5.0.4 / 5.4.5 / 5.7.3 / 5.9.3). |
| Lockfile bump | `pnpm-lock.yaml` | `pnpm install` regen for the typescript devDep change. |

## What this PR explicitly does NOT change

- **No tsup migration.** Replacing tsup with `tsdown` / `unbuild` / direct `tsc + esbuild` is the long-term fix for tsup#1388, but is out of scope here. `ignoreDeprecations` is a temporary bridge until that landing.
- **No `tsconfig.compat.json` change.** That config has no `baseUrl` and is consumed only via `pnpm dlx --package=typescript@${VERSION}` against `dist/*.d.ts` after the build — unaffected by tsup's TS6 deprecation behavior.
- **No consumer-test additions.** `tests/type-compat/core-consumer.ts` and `tests/type-compat/providers-consumer.ts` (added in #119) already exercise the full 9-entry public API surface (main + 8 provider subpaths).

## Test plan

- [x] `pnpm install` — clean (typescript 5.9.3 → 6.0.3 in lockfile)
- [x] `pnpm typecheck` — clean on TS 6.0.3
- [x] `pnpm build` — ESM + CJS + DTS clean (DTS step would fail on TS6 without `ignoreDeprecations`)
- [x] `pnpm test` — 193/193 pass
- [x] `pnpm test:compat` — clean
- [x] `pnpm dlx --package=typescript@5.0.4 -c 'tsc -p tsconfig.compat.json'` — clean (lower bound)
- [x] `pnpm dlx --package=typescript@5.4.5 -c 'tsc -p tsconfig.compat.json'` — clean
- [x] `pnpm dlx --package=typescript@5.7.3 -c 'tsc -p tsconfig.compat.json'` — clean
- [x] `pnpm dlx --package=typescript@5.9.3 -c 'tsc -p tsconfig.compat.json'` — clean
- [x] `pnpm dlx --package=typescript@6.0.3 -c 'tsc -p tsconfig.compat.json'` — clean (upper bound)
- [ ] CI green: `ci` (Node 22, 24) + `type-compat` (TS 5.0.4 / 5.4.5 / 5.7.3 / 5.9.3 / **6.0.3**)

## Removal plan for `ignoreDeprecations`

The escape hatch is intentionally temporary. Two events that should retire it:

1. **tsup releases a fix for #1388** (bundler stops injecting `baseUrl`) — drop the line, no other change needed.
2. **Project migrates off tsup** — drop the line during the build-toolchain swap PR.

When TS 7 ships, the `"6.0"` value stops being valid and CI will surface it as an error on the next major TS bump, forcing the cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
