### PR TITLE
ci: bump GitHub Actions to v6 (Node 24 internal runtime, GHA Node-20 deprecation)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,11 +13,11 @@ jobs:
       matrix:
         node-version: [22, 24]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
           cache: pnpm
@@ -40,11 +40,11 @@ jobs:
       matrix:
         ts: ["5.0.4", "5.4.5", "5.7.3", "5.9.3", "6.0.3"]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: pnpm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,9 +17,9 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v6
         with:
           # Node 24 ships with npm 11.x (required for OIDC Trusted Publishing).
           # Node 22 ships with npm 10.x and self-upgrading via 'npm install -g npm@latest' is unreliable in CI.


### PR DESCRIPTION
## Summary

GitHub Actions is deprecating Node 20 as the **JS-action internal runtime**:

> Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: `actions/checkout@v4`, `actions/setup-node@v4`, `pnpm/action-setup@v4`. **Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026.** Node.js 20 will be removed from the runner on **September 16th, 2026**.

This was surfaced as an annotation on the release workflow run for `Version Packages (#118)`.

## Why this is independent of #117

Two different "Node 20"s are in play:

| Axis | What it is | Status |
|---|---|---|
| **Library runtime** (`engines.node`) | What end-users install to run `hono-webhook-verify` | ✅ Done in #117 (`>=22`) |
| **GitHub Actions JS runtime** | What `actions/checkout` etc. use *internally* to execute their own JS | ❌ This PR fixes it |

The `node-version:` we pass to `setup-node` only affects the workflow steps' Node — it does **not** influence which Node the consumed JS actions themselves run on. Bumping the action major versions is the only fix.

## Bumps

| Action | Old | New | Latest available |
|---|---|---|---|
| `actions/checkout` | `@v4` | `@v6` | v6.0.2 |
| `actions/setup-node` | `@v4` | `@v6` | v6.4.0 |
| `pnpm/action-setup` | `@v4` | `@v6` | v6.0.4 |
| `changesets/action` | `@v1` | unchanged | not flagged in the deprecation |

Affected files: `.github/workflows/ci.yml` (6 refs across the `ci` and `type-compat` jobs), `.github/workflows/release.yml` (3 refs).

## Out of scope (explicit)

- **No SHA pinning.** Pinning to commit SHAs (as the sister repos do) is a supply-chain hardening that belongs in a separate PR — see the follow-up note in #119.
- **No corepack / cache changes.** Same reason.

## Test plan

- [x] `grep '@v' .github/workflows/*.yml` — only `changesets/action@v1` and the new `@v6` refs remain
- [ ] CI green: `ci` (Node 22, 24) + `type-compat` (TS 5.0.4 / 5.4.5 / 5.7.3 / 5.9.3 / 6.0.3) — should produce **no** Node-20-action deprecation annotation
- [ ] Release workflow stays valid (next `Version Packages` PR will use the new actions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
