### PR TITLE
ci(deps): group vitest and @vitest/* in Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,12 @@ updates:
       actions:
         patterns:
           - "*"
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      vitest:
+        patterns:
+          - "vitest"
+          - "@vitest/*"


### PR DESCRIPTION
## なぜ

#125 で Dependabot が `vitest` を 4.x に上げる一方、companion の `@vitest/coverage-v8` を 3.x に残し、版ズレで coverage 実行が `TypeError: Cannot read properties of undefined (reading 'fetchCache')` でクラッシュした。

`@vitest/coverage-v8` はパッチ一致の `vitest` を peer dependency に要求するため、両者は常に同一バージョンで更新する必要がある。

## 何を

`.github/dependabot.yml` に npm エコシステムのエントリを追加し、`vitest` と `@vitest/*` を1グループにまとめた。これにより両者が単一の grouped PR・単一の lockfile 解決で更新され、版ズレ事故を構造的に防ぐ。

```yaml
  - package-ecosystem: "npm"
    directory: "/"
    schedule:
      interval: "weekly"
    groups:
      vitest:
        patterns:
          - "vitest"
          - "@vitest/*"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved dependency update management with enhanced automation configuration for testing tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->