### PR TITLE
security: bump hono devDep and peerDep to fix multiple CVEs

### DIFF
--- a/package.json
+++ b/package.json
@@ -161,7 +161,7 @@
 		"node": ">=22"
 	},
 	"peerDependencies": {
-		"hono": ">=4.0.0",
+		"hono": ">=4.12.25",
 		"hono-problem-details": ">=0.1.0"
 	},
 	"peerDependenciesMeta": {
@@ -174,7 +174,7 @@
 		"@changesets/changelog-github": "0.7.0",
 		"@changesets/cli": "2.29.8",
 		"@vitest/coverage-v8": "^4.1.8",
-		"hono": "^4.7.0",
+		"hono": "^4.12.27",
 		"hono-problem-details": "0.1.4",
 		"lefthook": "2.1.1",
 		"tsup": "^8.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,11 +21,11 @@ importers:
         specifier: ^4.1.8
         version: 4.1.8(vitest@4.1.8)
       hono:
-        specifier: ^4.7.0
-        version: 4.12.23
+        specifier: ^4.12.27
+        version: 4.12.27
       hono-problem-details:
         specifier: 0.1.4
-        version: 0.1.4(hono@4.12.23)
+        version: 0.1.4(hono@4.12.27)
       lefthook:
         specifier: 2.1.1
         version: 2.1.1
@@ -1073,8 +1073,8 @@ packages:
       zod:
         optional: true
 
-  hono@4.12.23:
-    resolution: {integrity: sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA==}
+  hono@4.12.27:
+    resolution: {integrity: sha512-1yrb/+w6HWQJrUCLkJ2IF5jNIPvvFkblV5RNOYl6bV+OA6p9GLcMpHFFGTosSvHvcAUibuUukRqhlYI4z32C7Q==}
     engines: {node: '>=16.9.0'}
 
   html-escaper@2.0.2:
@@ -2494,11 +2494,11 @@ snapshots:
 
   has-flag@4.0.0: {}
 
-  hono-problem-details@0.1.4(hono@4.12.23):
+  hono-problem-details@0.1.4(hono@4.12.27):
     dependencies:
-      hono: 4.12.23
+      hono: 4.12.27
 
-  hono@4.12.23: {}
+  hono@4.12.27: {}
 
   html-escaper@2.0.2: {}
 


### PR DESCRIPTION
## Security Update

### Changes
- `hono` devDependency: `^4.7.0` → `^4.12.27` — CI now runs against a patched release
- `hono` peerDependency: `>=4.0.0` → `>=4.12.25` — end-users required to be on safe version

### CVEs addressed (all fixed in hono 4.12.25)

| Advisory | Severity | Description |
|---|---|---|
| GHSA-88fw-hqm2-52qc | **High** | CORS middleware reflects any Origin with credentials |
| GHSA-wwfh-h76j-fc44 | Moderate | serve-static path traversal on Windows via encoded backslash |
| GHSA-xgm2-5f3f-mvvc | Moderate | API Gateway v1 drops repeated request header value |
| GHSA-w62v-xxxg-mg59 | Moderate | Server-Side XSS via JSX escaping bypass in cx() |
| GHSA-hvrm-45r6-mjfj | Moderate | hono/jsx context not isolated per request |
| GHSA-rv63-4mwf-qqc2 | Moderate | Body Limit bypass on AWS Lambda |
| GHSA-wgpf-jwqj-8h8p | Moderate | Lambda@Edge drops repeated request header |
| GHSA-j6c9-x7qj-28xf | Moderate | AWS Lambda merges multiple Set-Cookie headers |
| GHSA-2gcr-mfcq-wcc3 | Moderate | app.mount() strips mount prefix on undecoded path |
| GHSA-xrhx-7g5j-rcj5 | Moderate | IP Restriction bypass for non-canonical IPv6 |
+ many earlier advisories (cookie prefix bypass, JWT algorithm confusion, etc.)

The peerDep bump is a **semver-breaking change** for consumers still on hono <4.12.25. Given the High-severity CORS credential leak and the volume of Moderate advisories, requiring an in-range patch upgrade is the appropriate security response.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the supported version requirements for a core dependency to newer releases.
  * Aligned development tooling with the latest compatible version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->