### PR TITLE
security: bump hono and update stale js-yaml/nanoid overrides

### DIFF
--- a/package.json
+++ b/package.json
@@ -179,7 +179,7 @@
 		"node": ">=22"
 	},
 	"peerDependencies": {
-		"hono": ">=4.12.27",
+		"hono": ">=4.12.34",
 		"hono-problem-details": ">=0.1.0"
 	},
 	"peerDependenciesMeta": {
@@ -192,7 +192,7 @@
 		"@changesets/changelog-github": "0.7.0",
 		"@changesets/cli": "2.31.1",
 		"@vitest/coverage-v8": "^4.1.8",
-		"hono": "^4.12.27",
+		"hono": "^4.12.34",
 		"hono-problem-details": "0.10.0",
 		"lefthook": "2.1.10",
 		"tsup": "^8.0.0",
@@ -209,9 +209,10 @@
 		"overrides": {
 			"vite@<7.3.5": "^7.3.5",
 			"esbuild@<0.28.1": "^0.28.1",
-			"js-yaml@<4.3.0": "^4.3.0",
+			"js-yaml@<4.3.1": "^4.3.1",
 			"yaml@<2.8.3": "^2.8.3",
-			"postcss@<8.5.18": "^8.5.18"
+			"postcss@<8.5.18": "^8.5.18",
+			"nanoid@<3.3.17": "^3.3.18"
 		}
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,9 +7,10 @@ settings:
 overrides:
   vite@<7.3.5: ^7.3.5
   esbuild@<0.28.1: ^0.28.1
-  js-yaml@<4.3.0: ^4.3.0
+  js-yaml@<4.3.1: ^4.3.1
   yaml@<2.8.3: ^2.8.3
   postcss@<8.5.18: ^8.5.18
+  nanoid@<3.3.17: ^3.3.18
 
 importers:
 
@@ -28,11 +29,11 @@ importers:
         specifier: ^4.1.8
         version: 4.1.10(vitest@4.1.10)
       hono:
-        specifier: ^4.12.27
-        version: 4.12.32
+        specifier: ^4.12.34
+        version: 4.13.1
       hono-problem-details:
         specifier: 0.10.0
-        version: 0.10.0(@standard-schema/spec@1.1.0)(hono@4.12.32)
+        version: 0.10.0(@standard-schema/spec@1.1.0)(hono@4.13.1)
       lefthook:
         specifier: 2.1.10
         version: 2.1.10
@@ -895,8 +896,8 @@ packages:
       zod:
         optional: true
 
-  hono@4.12.32:
-    resolution: {integrity: sha512-XcuyW9qE2kJn07PkecMOBd5Vq/hMy7mmGw+idz1yblbg9N17ijJODrvPkn7/dwL3Kulj8LcRJ69DLOWf91dRUg==}
+  hono@4.13.1:
+    resolution: {integrity: sha512-kdJoFVv2xmayw6cY09H7AbMJMt8Jn5jdlEdXsP7AGBdF2DIptVlKlOLKXP41yPip4/a3yQPv9gVcJYI8YY04dw==}
     engines: {node: '>=16.9.0'}
 
   html-escaper@2.0.2:
@@ -956,8 +957,8 @@ packages:
   js-tokens@10.0.0:
     resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
 
-  js-yaml@4.3.0:
-    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
+  js-yaml@4.3.1:
+    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
     hasBin: true
 
   jsonfile@4.0.0:
@@ -1066,8 +1067,8 @@ packages:
   mz@2.7.0:
     resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
 
-  nanoid@3.3.16:
-    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -1622,7 +1623,7 @@ snapshots:
   '@changesets/parse@0.4.3':
     dependencies:
       '@changesets/types': 6.1.0
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
 
   '@changesets/pre@2.0.2':
     dependencies:
@@ -2178,13 +2179,13 @@ snapshots:
 
   has-flag@4.0.0: {}
 
-  hono-problem-details@0.10.0(@standard-schema/spec@1.1.0)(hono@4.12.32):
+  hono-problem-details@0.10.0(@standard-schema/spec@1.1.0)(hono@4.13.1):
     dependencies:
-      hono: 4.12.32
+      hono: 4.13.1
     optionalDependencies:
       '@standard-schema/spec': 1.1.0
 
-  hono@4.12.32: {}
+  hono@4.13.1: {}
 
   html-escaper@2.0.2: {}
 
@@ -2229,7 +2230,7 @@ snapshots:
 
   js-tokens@10.0.0: {}
 
-  js-yaml@4.3.0:
+  js-yaml@4.3.1:
     dependencies:
       argparse: 2.0.1
 
@@ -2330,7 +2331,7 @@ snapshots:
       object-assign: 4.1.1
       thenify-all: 1.6.0
 
-  nanoid@3.3.16: {}
+  nanoid@3.3.18: {}
 
   node-fetch@2.7.0:
     dependencies:
@@ -2394,7 +2395,7 @@ snapshots:
 
   postcss@8.5.23:
     dependencies:
-      nanoid: 3.3.16
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -2407,7 +2408,7 @@ snapshots:
   read-yaml-file@1.1.0:
     dependencies:
       graceful-fs: 4.2.11
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       pify: 4.0.1
       strip-bom: 3.0.0
 


### PR DESCRIPTION
## Summary

- `hono` peer floor raised `>=4.12.27` → `>=4.12.34` and dev range `^4.12.27` → `^4.12.34` (lockfile now resolves `4.13.1`), fixing 4 advisories fixed in 4.12.34: [GHSA-8j4g-w8fx-2239](https://github.com/advisories/GHSA-8j4g-w8fx-2239) (CORS ReDoS, moderate), [GHSA-f23p-vx2j-j53r](https://github.com/advisories/GHSA-f23p-vx2j-j53r) (`memo()` cross-user SSR disclosure, moderate), [GHSA-54fx-42gc-7vw4](https://github.com/advisories/GHSA-54fx-42gc-7vw4) (language middleware algorithmic complexity DoS, moderate), [GHSA-79qm-7rj5-m7r9](https://github.com/advisories/GHSA-79qm-7rj5-m7r9) (proxy helper header leak, low)
- `js-yaml` override bumped `<4.3.0 → ^4.3.0` to `<4.3.1 → ^4.3.1`: the previous override pinned to `4.3.0`, which predates the fix for [GHSA-5p4m-2wfm-xmqj](https://github.com/advisories/GHSA-5p4m-2wfm-xmqj) (CVE-2026-59870, high, quadratic CPU consumption in `!!omap` resolution). Transitive path: `.>@changesets/cli>@changesets/read>@changesets/parse>js-yaml`
- New `nanoid` override `<3.3.17 → ^3.3.18` added: [GHSA-2v37-7h3g-55p8](https://github.com/advisories/GHSA-2v37-7h3g-55p8) (high) — custom generators can loop indefinitely when size is zero. Transitive path: `.>tsup>postcss>nanoid` (was unpinned, resolved `3.3.16`)

Both transitive overrides are dev-only build toolchain deps, not part of the published package's runtime graph. `pnpm audit` is clean after this change (previously 1 low, 3 moderate, 2 high).

## Test plan

- [x] `pnpm lint` passes
- [x] `pnpm typecheck` passes
- [x] `pnpm test` passes (193 tests, coverage thresholds maintained)
- [ ] Added/updated tests for changed behavior — not applicable, dependency version bumps only
- [ ] Added a changeset — not applicable, dev-only toolchain deps and a peer/dev range bump, no runtime behavior change

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bx4jW2ojWGe9zwEyJ7HnZL)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated framework and development dependency requirements.
  * Applied security and compatibility overrides for YAML parsing and identifier generation packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->