### PR TITLE
feat: add signStandardWebhook() to standard-webhooks provider

### DIFF
--- a/.changeset/sign-standard-webhook.md
+++ b/.changeset/sign-standard-webhook.md
@@ -3,3 +3,5 @@
 ---
 
 Add `signStandardWebhook()` to `hono-webhook-verify/providers/standard-webhooks`, mirroring `standardWebhooks()`'s verification logic to produce the `webhook-id` / `webhook-timestamp` / `webhook-signature` headers a sender needs. Accepts `secret` or a `secrets` array — the latter emits one space-separated `v1,` signature per secret for key rotation, matching the format the verifier already accepts.
+
+`standardWebhooks()` now throws `"standard-webhooks: secret must not be empty"` at construction time for an empty (or `whsec_`-only) secret, matching the other providers, instead of failing later inside Web Crypto key import.

--- a/.changeset/sign-standard-webhook.md
+++ b/.changeset/sign-standard-webhook.md
@@ -1,0 +1,5 @@
+---
+"hono-webhook-verify": minor
+---
+
+Add `signStandardWebhook()` to `hono-webhook-verify/providers/standard-webhooks`, mirroring `standardWebhooks()`'s verification logic to produce the `webhook-id` / `webhook-timestamp` / `webhook-signature` headers a sender needs. Accepts `secret` or a `secrets` array — the latter emits one space-separated `v1,` signature per secret for key rotation, matching the format the verifier already accepts.

--- a/README.md
+++ b/README.md
@@ -158,6 +158,27 @@ webhookVerify({
 });
 ```
 
+To send your own Standard Webhooks-formatted webhooks, `signStandardWebhook()` mirrors
+the provider's verification logic and produces the headers a receiver expects:
+
+```ts
+import { signStandardWebhook } from "hono-webhook-verify/providers/standard-webhooks";
+
+const headers = await signStandardWebhook({
+  secret: "whsec_...", // same handling as standardWebhooks(): optional whsec_ prefix
+  id: "msg_01j...",
+  timestamp: 1755300000, // optional, seconds; defaults to Math.floor(Date.now() / 1000)
+  body: rawBodyString,
+});
+// => { "webhook-id": "msg_01j...", "webhook-timestamp": "1755300000", "webhook-signature": "v1,..." }
+
+await fetch(destinationUrl, { method: "POST", headers, body: rawBodyString });
+```
+
+Pass `secrets: string[]` instead of `secret` to sign with multiple secrets for key
+rotation — one `v1,` signature is emitted per secret, space-separated, matching the
+format `standardWebhooks()` already accepts on the receiving end.
+
 ### Custom Provider
 
 Use `defineProvider()` with the built-in crypto utilities to create a provider for any webhook source:

--- a/README.md
+++ b/README.md
@@ -177,7 +177,13 @@ await fetch(destinationUrl, { method: "POST", headers, body: rawBodyString });
 
 Pass `secrets: string[]` instead of `secret` to sign with multiple secrets for key
 rotation — one `v1,` signature is emitted per secret, space-separated, matching the
-format `standardWebhooks()` already accepts on the receiving end.
+format `standardWebhooks()` already accepts on the receiving end. At most 10 secrets
+are accepted, since the verifier only inspects the first 10 signatures.
+
+`signStandardWebhook()` throws on an empty or non-base64 secret, on more than 10
+secrets, on a non-positive or non-integer timestamp, and on an `id` that is empty,
+contains whitespace or non-ASCII characters, or contains `.` (the Standard Webhooks
+spec forbids `.` in ids because the signed content is `id.timestamp.body`).
 
 ### Custom Provider
 

--- a/llms.txt
+++ b/llms.txt
@@ -34,7 +34,7 @@ The middleware reads the raw request body once, runs constant-time signature ver
 - [Twilio](https://github.com/paveg/hono-webhook-verify/blob/main/src/providers/twilio.ts): HMAC-SHA1 over URL plus form params (`X-Twilio-Signature`).
 - [LINE](https://github.com/paveg/hono-webhook-verify/blob/main/src/providers/line.ts): HMAC-SHA256 base64 (`X-Line-Signature`).
 - [Discord](https://github.com/paveg/hono-webhook-verify/blob/main/src/providers/discord.ts): Ed25519 asymmetric verification (`X-Signature-Ed25519`).
-- [Standard Webhooks](https://github.com/paveg/hono-webhook-verify/blob/main/src/providers/standard-webhooks.ts): svix-compatible HMAC-SHA256 (`webhook-signature`).
+- [Standard Webhooks](https://github.com/paveg/hono-webhook-verify/blob/main/src/providers/standard-webhooks.ts): svix-compatible HMAC-SHA256 (`webhook-signature`); also exports `signStandardWebhook()` for outbound signing.
 - [Provider types](https://github.com/paveg/hono-webhook-verify/blob/main/src/providers/types.ts): Shared provider option and result shapes.
 
 ## Optional

--- a/src/providers/standard-webhooks.ts
+++ b/src/providers/standard-webhooks.ts
@@ -52,9 +52,13 @@ export interface StandardWebhookHeaders extends Record<string, string> {
 
 const WHSEC_PREFIX = "whsec_";
 const MAX_SIGNATURES = 10;
+const PRINTABLE_ASCII_NO_DOT = /^[\x21-\x7E]+$/;
 
 function decodeSecret(secret: string): ArrayBuffer {
 	const base64Key = secret.startsWith(WHSEC_PREFIX) ? secret.slice(WHSEC_PREFIX.length) : secret;
+	if (!base64Key) {
+		throw new Error("standard-webhooks: secret must not be empty");
+	}
 	const keyBytes = fromBase64(base64Key);
 	if (!keyBytes) {
 		throw new Error("standard-webhooks: secret must be valid base64 (with optional whsec_ prefix)");
@@ -80,8 +84,15 @@ export async function signStandardWebhook(
 		);
 	}
 	const timestamp = options.timestamp ?? Math.floor(Date.now() / 1000);
-	if (!Number.isSafeInteger(timestamp)) {
-		throw new Error("standard-webhooks: timestamp must be an integer number of seconds");
+	if (!Number.isSafeInteger(timestamp) || timestamp <= 0) {
+		throw new Error("standard-webhooks: timestamp must be a positive integer number of seconds");
+	}
+	// The Standard Webhooks spec forbids '.' in ids because the signed content is
+	// `id.timestamp.body`; Headers also rejects whitespace and non-ASCII characters.
+	if (!PRINTABLE_ASCII_NO_DOT.test(options.id) || options.id.includes(".")) {
+		throw new Error(
+			"standard-webhooks: id must be non-empty printable ASCII without whitespace or '.'",
+		);
 	}
 	const signedContent = `${options.id}.${timestamp}.${options.body}`;
 

--- a/src/providers/standard-webhooks.ts
+++ b/src/providers/standard-webhooks.ts
@@ -9,24 +9,42 @@ export interface StandardWebhooksOptions {
 	tolerance?: number;
 }
 
-export interface SignStandardWebhookOptions {
-	/** Signing secret. Accepts the whsec_ prefix (stripped), same as the verifier. */
-	secret?: string;
-	/**
-	 * Multiple signing secrets for key rotation. One `v1,` signature is emitted per
-	 * secret, space-separated — the same format the verifier already accepts.
-	 * Takes precedence over `secret` when both are provided.
-	 */
-	secrets?: string[];
+/**
+ * Signing credentials for `signStandardWebhook()`. At least one of `secret` or
+ * `secrets` is required; when both are given, `secrets` takes precedence.
+ */
+type SignStandardWebhookCredentials =
+	| {
+			/** Signing secret. Accepts the whsec_ prefix (stripped), same as the verifier. */
+			secret: string;
+			/**
+			 * Multiple signing secrets for key rotation. One `v1,` signature is emitted per
+			 * secret, space-separated — the same format the verifier already accepts.
+			 * Takes precedence over `secret` when both are provided.
+			 */
+			secrets?: string[];
+	  }
+	| {
+			secret?: string;
+			/**
+			 * Multiple signing secrets for key rotation. One `v1,` signature is emitted per
+			 * secret, space-separated — the same format the verifier already accepts.
+			 */
+			secrets: string[];
+	  };
+
+export type SignStandardWebhookOptions = SignStandardWebhookCredentials & {
 	/** Message id, sent back as the `webhook-id` header. */
 	id: string;
 	/** Signing timestamp in seconds (default: the current time). */
 	timestamp?: number;
 	/** Raw request body to sign. */
 	body: string;
-}
+};
 
-export interface StandardWebhookHeaders {
+// Extends Record<string, string> so the result is directly assignable to
+// HeadersInit (e.g. `new Headers(headers)`, `fetch(url, { headers })`).
+export interface StandardWebhookHeaders extends Record<string, string> {
 	"webhook-id": string;
 	"webhook-timestamp": string;
 	"webhook-signature": string;

--- a/src/providers/standard-webhooks.ts
+++ b/src/providers/standard-webhooks.ts
@@ -56,7 +56,15 @@ export async function signStandardWebhook(
 	if (secrets.length === 0) {
 		throw new Error("standard-webhooks: signStandardWebhook requires `secret` or `secrets`");
 	}
+	if (secrets.length > MAX_SIGNATURES) {
+		throw new Error(
+			`standard-webhooks: signStandardWebhook supports at most ${MAX_SIGNATURES} secrets`,
+		);
+	}
 	const timestamp = options.timestamp ?? Math.floor(Date.now() / 1000);
+	if (!Number.isSafeInteger(timestamp)) {
+		throw new Error("standard-webhooks: timestamp must be an integer number of seconds");
+	}
 	const signedContent = `${options.id}.${timestamp}.${options.body}`;
 
 	const signatures = await Promise.all(

--- a/src/providers/standard-webhooks.ts
+++ b/src/providers/standard-webhooks.ts
@@ -46,7 +46,7 @@ export type StandardWebhookHeaders = {
 
 const WHSEC_PREFIX = "whsec_";
 const MAX_SIGNATURES = 10;
-const PRINTABLE_ASCII_NO_DOT = /^[\x21-\x7E]+$/;
+const PRINTABLE_ASCII = /^[\x21-\x7E]+$/;
 
 function decodeSecret(secret: string): ArrayBuffer {
 	const base64Key = secret.startsWith(WHSEC_PREFIX) ? secret.slice(WHSEC_PREFIX.length) : secret;
@@ -85,7 +85,7 @@ export async function signStandardWebhook(
 	}
 	// The Standard Webhooks spec forbids '.' in ids because the signed content is
 	// `id.timestamp.body`; Headers also rejects whitespace and non-ASCII characters.
-	if (!PRINTABLE_ASCII_NO_DOT.test(options.id) || options.id.includes(".")) {
+	if (!PRINTABLE_ASCII.test(options.id) || options.id.includes(".")) {
 		throw new Error(
 			"standard-webhooks: id must be non-empty printable ASCII without whitespace or '.'",
 		);

--- a/src/providers/standard-webhooks.ts
+++ b/src/providers/standard-webhooks.ts
@@ -1,5 +1,5 @@
 import { DEFAULT_TOLERANCE_S } from "../constants.js";
-import { fromBase64, hmac, timingSafeEqual } from "../crypto.js";
+import { fromBase64, hmac, timingSafeEqual, toBase64 } from "../crypto.js";
 import { validateTimestamp } from "../timestamp.js";
 import type { WebhookProvider } from "./types.js";
 
@@ -9,18 +9,74 @@ export interface StandardWebhooksOptions {
 	tolerance?: number;
 }
 
+export interface SignStandardWebhookOptions {
+	/** Signing secret. Accepts the whsec_ prefix (stripped), same as the verifier. */
+	secret?: string;
+	/**
+	 * Multiple signing secrets for key rotation. One `v1,` signature is emitted per
+	 * secret, space-separated — the same format the verifier already accepts.
+	 * Takes precedence over `secret` when both are provided.
+	 */
+	secrets?: string[];
+	/** Message id, sent back as the `webhook-id` header. */
+	id: string;
+	/** Signing timestamp in seconds (default: the current time). */
+	timestamp?: number;
+	/** Raw request body to sign. */
+	body: string;
+}
+
+export interface StandardWebhookHeaders {
+	"webhook-id": string;
+	"webhook-timestamp": string;
+	"webhook-signature": string;
+}
+
 const WHSEC_PREFIX = "whsec_";
 const MAX_SIGNATURES = 10;
 
-export function standardWebhooks(options: StandardWebhooksOptions): WebhookProvider {
-	const { tolerance = DEFAULT_TOLERANCE_S } = options;
-	const base64Key = options.secret.startsWith(WHSEC_PREFIX)
-		? options.secret.slice(WHSEC_PREFIX.length)
-		: options.secret;
+function decodeSecret(secret: string): ArrayBuffer {
+	const base64Key = secret.startsWith(WHSEC_PREFIX) ? secret.slice(WHSEC_PREFIX.length) : secret;
 	const keyBytes = fromBase64(base64Key);
 	if (!keyBytes) {
 		throw new Error("standard-webhooks: secret must be valid base64 (with optional whsec_ prefix)");
 	}
+	return keyBytes;
+}
+
+/**
+ * Sign a payload in the Standard Webhooks format, mirroring `standardWebhooks()`'s
+ * verification logic. Produces the three headers a sender needs to attach to an
+ * outbound webhook request.
+ */
+export async function signStandardWebhook(
+	options: SignStandardWebhookOptions,
+): Promise<StandardWebhookHeaders> {
+	const secrets = options.secrets ?? (options.secret !== undefined ? [options.secret] : []);
+	if (secrets.length === 0) {
+		throw new Error("standard-webhooks: signStandardWebhook requires `secret` or `secrets`");
+	}
+	const timestamp = options.timestamp ?? Math.floor(Date.now() / 1000);
+	const signedContent = `${options.id}.${timestamp}.${options.body}`;
+
+	const signatures = await Promise.all(
+		secrets.map(async (secret) => {
+			const keyBytes = decodeSecret(secret);
+			const sig = await hmac("SHA-256", keyBytes, signedContent);
+			return `v1,${toBase64(sig)}`;
+		}),
+	);
+
+	return {
+		"webhook-id": options.id,
+		"webhook-timestamp": String(timestamp),
+		"webhook-signature": signatures.join(" "),
+	};
+}
+
+export function standardWebhooks(options: StandardWebhooksOptions): WebhookProvider {
+	const { tolerance = DEFAULT_TOLERANCE_S } = options;
+	const keyBytes = decodeSecret(options.secret);
 
 	return {
 		name: "standard-webhooks",

--- a/src/providers/standard-webhooks.ts
+++ b/src/providers/standard-webhooks.ts
@@ -10,25 +10,21 @@ export interface StandardWebhooksOptions {
 }
 
 /**
- * Signing credentials for `signStandardWebhook()`. At least one of `secret` or
- * `secrets` is required; when both are given, `secrets` takes precedence.
+ * Signing credentials for `signStandardWebhook()`. Exactly one of `secret` or
+ * `secrets` is required.
  */
 type SignStandardWebhookCredentials =
 	| {
 			/** Signing secret. Accepts the whsec_ prefix (stripped), same as the verifier. */
 			secret: string;
-			/**
-			 * Multiple signing secrets for key rotation. One `v1,` signature is emitted per
-			 * secret, space-separated — the same format the verifier already accepts.
-			 * Takes precedence over `secret` when both are provided.
-			 */
-			secrets?: string[];
+			secrets?: never;
 	  }
 	| {
-			secret?: string;
+			secret?: never;
 			/**
-			 * Multiple signing secrets for key rotation. One `v1,` signature is emitted per
-			 * secret, space-separated — the same format the verifier already accepts.
+			 * Multiple signing secrets for key rotation (max 10). One `v1,` signature is
+			 * emitted per secret, space-separated — the same format the verifier already
+			 * accepts.
 			 */
 			secrets: string[];
 	  };
@@ -42,13 +38,11 @@ export type SignStandardWebhookOptions = SignStandardWebhookCredentials & {
 	body: string;
 };
 
-// Extends Record<string, string> so the result is directly assignable to
-// HeadersInit (e.g. `new Headers(headers)`, `fetch(url, { headers })`).
-export interface StandardWebhookHeaders extends Record<string, string> {
+export type StandardWebhookHeaders = {
 	"webhook-id": string;
 	"webhook-timestamp": string;
 	"webhook-signature": string;
-}
+};
 
 const WHSEC_PREFIX = "whsec_";
 const MAX_SIGNATURES = 10;
@@ -76,7 +70,9 @@ export async function signStandardWebhook(
 ): Promise<StandardWebhookHeaders> {
 	const secrets = options.secrets ?? (options.secret !== undefined ? [options.secret] : []);
 	if (secrets.length === 0) {
-		throw new Error("standard-webhooks: signStandardWebhook requires `secret` or `secrets`");
+		throw new Error(
+			"standard-webhooks: signStandardWebhook requires `secret` or a non-empty `secrets`",
+		);
 	}
 	if (secrets.length > MAX_SIGNATURES) {
 		throw new Error(

--- a/tests/providers/standard-webhooks.test.ts
+++ b/tests/providers/standard-webhooks.test.ts
@@ -512,4 +512,50 @@ describe("signStandardWebhook", () => {
 			signStandardWebhook({ secret: "!!invalid!!", id: MSG_ID, body: BODY }),
 		).rejects.toThrow("secret must be valid base64");
 	});
+
+	it("S9: throws when secrets exceeds the verifier's 10-signature limit", async () => {
+		const secrets = Array.from({ length: 11 }, () => SECRET);
+		await expect(
+			signStandardWebhook({ secrets, id: MSG_ID, timestamp: FIXED_TIMESTAMP, body: BODY }),
+		).rejects.toThrow("supports at most 10 secrets");
+	});
+
+	it("S10: accepts exactly 10 secrets (at the verifier's limit)", async () => {
+		const secrets = Array.from({ length: 10 }, () => SECRET);
+		const headers = await signStandardWebhook({
+			secrets,
+			id: MSG_ID,
+			timestamp: FIXED_TIMESTAMP,
+			body: BODY,
+		});
+		expect(headers["webhook-signature"].split(" ")).toHaveLength(10);
+	});
+
+	it("S11: throws on a fractional timestamp", async () => {
+		await expect(
+			signStandardWebhook({ secret: SECRET, id: MSG_ID, timestamp: 1755300000.5, body: BODY }),
+		).rejects.toThrow("timestamp must be an integer number of seconds");
+	});
+
+	it("S12: throws on a non-finite timestamp", async () => {
+		await expect(
+			signStandardWebhook({
+				secret: SECRET,
+				id: MSG_ID,
+				timestamp: Number.POSITIVE_INFINITY,
+				body: BODY,
+			}),
+		).rejects.toThrow("timestamp must be an integer number of seconds");
+	});
+
+	it("S13: throws on an unsafe-integer timestamp", async () => {
+		await expect(
+			signStandardWebhook({
+				secret: SECRET,
+				id: MSG_ID,
+				timestamp: Number.MAX_SAFE_INTEGER + 1,
+				body: BODY,
+			}),
+		).rejects.toThrow("timestamp must be an integer number of seconds");
+	});
 });

--- a/tests/providers/standard-webhooks.test.ts
+++ b/tests/providers/standard-webhooks.test.ts
@@ -449,7 +449,7 @@ describe("signStandardWebhook", () => {
 		expect(timestamp).toBeLessThanOrEqual(after);
 	});
 
-	it("S3: strips the whsec_ prefix like the verifier", async () => {
+	it("S3: verifies with the whsec_-prefixed secret when signed with the bare secret", async () => {
 		const headers = await signStandardWebhook({
 			secret: SECRET_BASE64,
 			id: MSG_ID,

--- a/tests/providers/standard-webhooks.test.ts
+++ b/tests/providers/standard-webhooks.test.ts
@@ -230,6 +230,10 @@ describe("standard-webhooks provider", () => {
 		);
 	});
 
+	it("throws on an empty secret", () => {
+		expect(() => standardWebhooks({ secret: "" })).toThrow("secret must not be empty");
+	});
+
 	it("accepts timestamp at exactly the tolerance boundary", async () => {
 		const provider = standardWebhooks({ secret: SECRET, tolerance: 60 });
 		const exactlyAtBoundary = Math.floor(Date.now() / 1000) - 60;
@@ -534,7 +538,7 @@ describe("signStandardWebhook", () => {
 	it("S11: throws on a fractional timestamp", async () => {
 		await expect(
 			signStandardWebhook({ secret: SECRET, id: MSG_ID, timestamp: 1755300000.5, body: BODY }),
-		).rejects.toThrow("timestamp must be an integer number of seconds");
+		).rejects.toThrow("timestamp must be a positive integer number of seconds");
 	});
 
 	it("S12: throws on a non-finite timestamp", async () => {
@@ -545,7 +549,7 @@ describe("signStandardWebhook", () => {
 				timestamp: Number.POSITIVE_INFINITY,
 				body: BODY,
 			}),
-		).rejects.toThrow("timestamp must be an integer number of seconds");
+		).rejects.toThrow("timestamp must be a positive integer number of seconds");
 	});
 
 	it("S13: throws on an unsafe-integer timestamp", async () => {
@@ -556,6 +560,80 @@ describe("signStandardWebhook", () => {
 				timestamp: Number.MAX_SAFE_INTEGER + 1,
 				body: BODY,
 			}),
-		).rejects.toThrow("timestamp must be an integer number of seconds");
+		).rejects.toThrow("timestamp must be a positive integer number of seconds");
+	});
+
+	it("throws on a zero timestamp", async () => {
+		await expect(
+			signStandardWebhook({ secret: SECRET, id: MSG_ID, timestamp: 0, body: BODY }),
+		).rejects.toThrow("timestamp must be a positive integer number of seconds");
+	});
+
+	it("throws on a negative timestamp", async () => {
+		await expect(
+			signStandardWebhook({ secret: SECRET, id: MSG_ID, timestamp: -5, body: BODY }),
+		).rejects.toThrow("timestamp must be a positive integer number of seconds");
+	});
+
+	it("throws on an empty id", async () => {
+		await expect(
+			signStandardWebhook({ secret: SECRET, id: "", timestamp: FIXED_TIMESTAMP, body: BODY }),
+		).rejects.toThrow("id must be non-empty printable ASCII without whitespace or '.'");
+	});
+
+	it("throws on a whitespace-padded id", async () => {
+		await expect(
+			signStandardWebhook({
+				secret: SECRET,
+				id: "  msg_1  ",
+				timestamp: FIXED_TIMESTAMP,
+				body: BODY,
+			}),
+		).rejects.toThrow("id must be non-empty printable ASCII without whitespace or '.'");
+	});
+
+	it("throws on a non-ASCII id", async () => {
+		await expect(
+			signStandardWebhook({
+				secret: SECRET,
+				id: "msg_あ",
+				timestamp: FIXED_TIMESTAMP,
+				body: BODY,
+			}),
+		).rejects.toThrow("id must be non-empty printable ASCII without whitespace or '.'");
+	});
+
+	it("throws on an id containing a CRLF header injection attempt", async () => {
+		await expect(
+			signStandardWebhook({
+				secret: SECRET,
+				id: "a\r\nx: 1",
+				timestamp: FIXED_TIMESTAMP,
+				body: BODY,
+			}),
+		).rejects.toThrow("id must be non-empty printable ASCII without whitespace or '.'");
+	});
+
+	it("throws on an id containing a '.'", async () => {
+		await expect(
+			signStandardWebhook({ secret: SECRET, id: "a.b", timestamp: FIXED_TIMESTAMP, body: BODY }),
+		).rejects.toThrow("id must be non-empty printable ASCII without whitespace or '.'");
+	});
+
+	it("throws on an empty secret", async () => {
+		await expect(
+			signStandardWebhook({ secret: "", id: MSG_ID, timestamp: FIXED_TIMESTAMP, body: BODY }),
+		).rejects.toThrow("secret must not be empty");
+	});
+
+	it("throws when the secret is only the whsec_ prefix", async () => {
+		await expect(
+			signStandardWebhook({
+				secret: "whsec_",
+				id: MSG_ID,
+				timestamp: FIXED_TIMESTAMP,
+				body: BODY,
+			}),
+		).rejects.toThrow("secret must not be empty");
 	});
 });

--- a/tests/providers/standard-webhooks.test.ts
+++ b/tests/providers/standard-webhooks.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { standardWebhooks } from "../../src/providers/standard-webhooks.js";
+import { signStandardWebhook, standardWebhooks } from "../../src/providers/standard-webhooks.js";
 import { EXPIRED_OFFSET_S } from "../helpers/constants.js";
 import { generateStandardWebhooksSignature } from "../helpers/signatures.js";
 
@@ -409,5 +409,107 @@ describe("standard-webhooks provider", () => {
 			}),
 		});
 		expect(result).toEqual({ valid: false, reason: "timestamp-expired" });
+	});
+});
+
+describe("signStandardWebhook", () => {
+	const FIXED_TIMESTAMP = Math.floor(Date.now() / 1000);
+
+	it("S1: round-trips through standardWebhooks().verify()", async () => {
+		const headers = await signStandardWebhook({
+			secret: SECRET,
+			id: MSG_ID,
+			timestamp: FIXED_TIMESTAMP,
+			body: BODY,
+		});
+		expect(headers).toEqual({
+			"webhook-id": MSG_ID,
+			"webhook-timestamp": String(FIXED_TIMESTAMP),
+			"webhook-signature": expect.stringMatching(/^v1,/),
+		});
+
+		const provider = standardWebhooks({ secret: SECRET });
+		const result = await provider.verify({
+			rawBody: BODY,
+			headers: new Headers(headers),
+		});
+		expect(result).toEqual({ valid: true });
+	});
+
+	it("S2: defaults timestamp to the current time in seconds", async () => {
+		const before = Math.floor(Date.now() / 1000);
+		const headers = await signStandardWebhook({ secret: SECRET, id: MSG_ID, body: BODY });
+		const after = Math.floor(Date.now() / 1000);
+		const timestamp = Number(headers["webhook-timestamp"]);
+		expect(timestamp).toBeGreaterThanOrEqual(before);
+		expect(timestamp).toBeLessThanOrEqual(after);
+	});
+
+	it("S3: strips the whsec_ prefix like the verifier", async () => {
+		const headers = await signStandardWebhook({
+			secret: SECRET_BASE64,
+			id: MSG_ID,
+			timestamp: FIXED_TIMESTAMP,
+			body: BODY,
+		});
+		const provider = standardWebhooks({ secret: SECRET });
+		const result = await provider.verify({ rawBody: BODY, headers: new Headers(headers) });
+		expect(result).toEqual({ valid: true });
+	});
+
+	it("S4: round-trips an empty body", async () => {
+		const headers = await signStandardWebhook({
+			secret: SECRET,
+			id: MSG_ID,
+			timestamp: FIXED_TIMESTAMP,
+			body: "",
+		});
+		const provider = standardWebhooks({ secret: SECRET });
+		const result = await provider.verify({ rawBody: "", headers: new Headers(headers) });
+		expect(result).toEqual({ valid: true });
+	});
+
+	it("S5: round-trips a multibyte body", async () => {
+		const body = '{"text":"こんにちは"}';
+		const headers = await signStandardWebhook({
+			secret: SECRET,
+			id: MSG_ID,
+			timestamp: FIXED_TIMESTAMP,
+			body,
+		});
+		const provider = standardWebhooks({ secret: SECRET });
+		const result = await provider.verify({ rawBody: body, headers: new Headers(headers) });
+		expect(result).toEqual({ valid: true });
+	});
+
+	it("S6: emits a space-separated signature per secret for key rotation", async () => {
+		const headers = await signStandardWebhook({
+			secrets: [SECRET, WRONG_SECRET],
+			id: MSG_ID,
+			timestamp: FIXED_TIMESTAMP,
+			body: BODY,
+		});
+		const signatures = headers["webhook-signature"].split(" ");
+		expect(signatures).toHaveLength(2);
+
+		// Verifies against either secret independently, mirroring the receiver's rotation support.
+		for (const secret of [SECRET, WRONG_SECRET]) {
+			const provider = standardWebhooks({ secret });
+			const result = await provider.verify({ rawBody: BODY, headers: new Headers(headers) });
+			expect(result).toEqual({ valid: true });
+		}
+	});
+
+	it("S7: throws when neither secret nor secrets is provided", async () => {
+		await expect(
+			// @ts-expect-error exercising the runtime guard for missing options
+			signStandardWebhook({ id: MSG_ID, timestamp: FIXED_TIMESTAMP, body: BODY }),
+		).rejects.toThrow("signStandardWebhook requires `secret` or `secrets`");
+	});
+
+	it("S8: throws on invalid base64 secret", async () => {
+		await expect(
+			signStandardWebhook({ secret: "!!invalid!!", id: MSG_ID, body: BODY }),
+		).rejects.toThrow("secret must be valid base64");
 	});
 });

--- a/tests/providers/standard-webhooks.test.ts
+++ b/tests/providers/standard-webhooks.test.ts
@@ -508,7 +508,7 @@ describe("signStandardWebhook", () => {
 		await expect(
 			// @ts-expect-error exercising the runtime guard for missing options
 			signStandardWebhook({ id: MSG_ID, timestamp: FIXED_TIMESTAMP, body: BODY }),
-		).rejects.toThrow("signStandardWebhook requires `secret` or `secrets`");
+		).rejects.toThrow("signStandardWebhook requires `secret` or a non-empty `secrets`");
 	});
 
 	it("S8: throws on invalid base64 secret", async () => {
@@ -635,5 +635,21 @@ describe("signStandardWebhook", () => {
 				body: BODY,
 			}),
 		).rejects.toThrow("secret must not be empty");
+	});
+
+	it("throws when secrets is an empty array", async () => {
+		await expect(
+			signStandardWebhook({ secrets: [], id: MSG_ID, timestamp: FIXED_TIMESTAMP, body: BODY }),
+		).rejects.toThrow("signStandardWebhook requires `secret` or a non-empty `secrets`");
+	});
+
+	it("S14: matches the reference implementation's signature (known-answer vector)", async () => {
+		const headers = await signStandardWebhook({
+			secret: "MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY=",
+			id: "msg_2b1c3d4e5f",
+			timestamp: 1755300000,
+			body: '{"event":"ping","n":1}',
+		});
+		expect(headers["webhook-signature"]).toBe("v1,AKA3rHe5r1ZckfgaJAOjjWQ2J999Qbaqxu4Ekf24A+c=");
 	});
 });

--- a/tests/type-compat/providers-consumer.ts
+++ b/tests/type-compat/providers-consumer.ts
@@ -34,7 +34,7 @@ const _line = line(_lineOpts);
 const _discord = discord(_discordOpts);
 const _sw = standardWebhooks(_swOpts);
 
-// signStandardWebhook: at least one of `secret` / `secrets` is required at the type level.
+// signStandardWebhook: exactly one of `secret` / `secrets` is required at the type level.
 const _signOptsSecret: SignStandardWebhookOptions = {
 	secret: "whsec_swh",
 	id: "msg_1",
@@ -47,6 +47,11 @@ const _signOptsSecrets: SignStandardWebhookOptions = {
 };
 const _signHeaders: Promise<StandardWebhookHeaders> = signStandardWebhook(_signOptsSecret);
 void signStandardWebhook(_signOptsSecrets);
+
+// @ts-expect-error secret and secrets are mutually exclusive
+void signStandardWebhook({ secret: "whsec_a", secrets: ["whsec_b"], id: "msg_1", body: "{}" });
+// @ts-expect-error at least one of secret / secrets is required
+void signStandardWebhook({ id: "msg_1", body: "{}" });
 
 // The returned headers must be directly assignable to HeadersInit.
 async function _headersAssignable() {

--- a/tests/type-compat/providers-consumer.ts
+++ b/tests/type-compat/providers-consumer.ts
@@ -4,7 +4,10 @@ import { type LineOptions, line } from "../../dist/providers/line.js";
 import { type ShopifyOptions, shopify } from "../../dist/providers/shopify.js";
 import { type SlackOptions, slack } from "../../dist/providers/slack.js";
 import {
+	type SignStandardWebhookOptions,
+	type StandardWebhookHeaders,
 	type StandardWebhooksOptions,
+	signStandardWebhook,
 	standardWebhooks,
 } from "../../dist/providers/standard-webhooks.js";
 import { type StripeOptions, stripe } from "../../dist/providers/stripe.js";
@@ -30,6 +33,28 @@ const _twilio = twilio(_twilioOpts);
 const _line = line(_lineOpts);
 const _discord = discord(_discordOpts);
 const _sw = standardWebhooks(_swOpts);
+
+// signStandardWebhook: at least one of `secret` / `secrets` is required at the type level.
+const _signOptsSecret: SignStandardWebhookOptions = {
+	secret: "whsec_swh",
+	id: "msg_1",
+	body: "{}",
+};
+const _signOptsSecrets: SignStandardWebhookOptions = {
+	secrets: ["whsec_a", "whsec_b"],
+	id: "msg_1",
+	body: "{}",
+};
+const _signHeaders: Promise<StandardWebhookHeaders> = signStandardWebhook(_signOptsSecret);
+void signStandardWebhook(_signOptsSecrets);
+
+// The returned headers must be directly assignable to HeadersInit.
+async function _headersAssignable() {
+	const headers = await _signHeaders;
+	new Headers(headers);
+	await fetch("https://example.com", { method: "POST", headers, body: "{}" });
+}
+void _headersAssignable;
 
 void _stripe;
 void _github;


### PR DESCRIPTION
## Summary

- Add `signStandardWebhook({ secret | secrets, id, timestamp?, body })` to `src/providers/standard-webhooks.ts`, mirroring `standardWebhooks()`'s verification logic to produce the `webhook-id` / `webhook-timestamp` / `webhook-signature` headers a sender needs
- Extract a shared `decodeSecret()` helper (`whsec_` prefix strip + base64 decode) so `standardWebhooks()` and `signStandardWebhook()` can't drift apart
- `secrets: string[]` emits one space-separated `v1,` signature per secret, matching the rotation format the verifier already accepts

Fixes #163

## Test plan

- [x] `pnpm lint` passes
- [x] `pnpm typecheck` passes
- [x] `pnpm test` passes (201/201, up from 193)
- [x] Added round-trip tests (sign → `standardWebhooks().verify()`) covering default/explicit timestamp, `whsec_` prefix stripping, empty/multibyte bodies, key rotation via `secrets`, and error paths
- [x] Added a changeset (minor — new opt-in export)
- [x] `pnpm build` and `pnpm test:compat` also verified locally


---
_Generated by [Claude Code](https://claude.ai/code/session_019gSTdBY9Frtp5aYX4Pp4mN)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added outbound Standard Webhooks signing.
  * Supports single or multiple secrets for key rotation.
  * Generates standard webhook headers and timestamped HMAC-SHA256 signatures.
  * Accepts secrets with or without the `whsec_` prefix.
  * Supports custom timestamps, message IDs, and common request body formats.
  * Validates signing secrets, timestamps, message IDs, and secret rotation limits.

* **Documentation**
  * Added usage guidance, header examples, timestamp behavior, validation details, and key rotation instructions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->